### PR TITLE
Add Foundry v14 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.8
+- Foundry VTT v14 compatibility updates
+- Fixed Daggerheart v14 keyed damage parts handling
+- Safer compendium document cloning for v14 document validation
+
 # 0.2.7
 - Last release for v13
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,0 +1,324 @@
+{
+  "DHAM": {
+    "Common": {
+      "Adversaries": "Adversaries",
+      "Adversary": "Adversary",
+      "AllSources": "All Sources",
+      "AllTiers": "All Tiers",
+      "AllTypes": "All Types",
+      "ApplyChanges": "Apply Changes",
+      "AttackBonus": "Attack Bonus",
+      "AttackDamage": "Attack Damage",
+      "Base": "Base: {base}",
+      "ChooseAdversary": "-- Choose an Adversary --",
+      "Compendium": "Compendium",
+      "Critical": "Critical",
+      "CriticalThreshold": "Critical Threshold",
+      "Current": "Current",
+      "DamageType": "Damage Type:",
+      "Difficulty": "Difficulty",
+      "Direct": "Direct:",
+      "DirectNo": "Direct: No",
+      "DirectYes": "Direct: Yes",
+      "Experiences": "Experiences",
+      "Failure": "Failure",
+      "Feature": "Feature",
+      "Features": "Features",
+      "HalvedDamageHorde": "Halved Damage (Horde)",
+      "Homebrew": "Homebrew",
+      "HP": "HP",
+      "Linked": "Linked",
+      "ManualOverride": "Manual Override",
+      "Max": "Max",
+      "Mean": "Mean",
+      "Min": "Min",
+      "No": "No",
+      "None": "None",
+      "Preview": "Preview",
+      "Recommended": "Recommended",
+      "Remove": "Remove",
+      "RenameFeature": "Rename Feature",
+      "Stress": "Stress",
+      "Success": "Success",
+      "Suggested": "Suggested:",
+      "SystemCompendium": "System Compendium",
+      "Thresholds": "Thresholds",
+      "Tier": "Tier {tier}",
+      "Type": "Type",
+      "Unlinked": "Unlinked",
+      "World": "World",
+      "WorldActors": "World (Actors)",
+      "Yes": "Yes"
+    },
+    "Settings": {
+      "AddFeatures": {
+        "Hint": "If enabled, randomly suggests adding features when leveling up.",
+        "Name": "Auto-Add Features on Tier Up"
+      },
+      "ChatLog": {
+        "Hint": "If enabled, sends a whisper to the GM whenever an Adversary is updated via the Manager.",
+        "Name": "Log Changes to Chat"
+      },
+      "EncounterFolder": {
+        "Hint": "Name of the root folder where encounters created by the builder will be stored.",
+        "Name": "Encounter Folder Name"
+      },
+      "ExtraCompendiums": {
+        "Name": "Extra Compendiums (Actors)"
+      },
+      "FeatureCompendiums": {
+        "Name": "Feature Compendiums"
+      },
+      "ImportFolder": {
+        "Hint": "Name of the folder where adversaries imported from Compendiums will be created.",
+        "Name": "Compendium Import Folder"
+      },
+      "StatsCompendiums": {
+        "Name": "Stats Compendiums"
+      },
+      "SuggestFeatures": {
+        "Hint": "If enabled, shows the 'New Suggested Features' section in the Live Manager preview.",
+        "Name": "Enable Suggested Features"
+      },
+      "UpdateExp": {
+        "Hint": "If enabled, experiences will increase/decrease by 1 for each Tier change.",
+        "Name": "Auto-Update Experiences"
+      }
+    },
+    "Windows": {
+      "AdversaryLiveManager": "Adversary Live Manager",
+      "AdversaryManager": "Adversary Manager",
+      "CompendiumManager": "Manage Compendium Sources",
+      "CompendiumStats": "Compendium Statistics",
+      "DiceProbability": "Dice Probability Calculator",
+      "EncounterBuilder": "Encounter Builder",
+      "EncounterName": "Encounter Name",
+      "FeatureUpdater": "Feature Flag Updater",
+      "StatsManager": "Manage Stat Sources"
+    },
+    "ModuleMenu": {
+      "AdversaryTools": "Adversary Tools",
+      "CompendiumStats": "Compendium Stats",
+      "DiceProbability": "Dice Probability",
+      "EncounterBuilder": "Encounter Builder",
+      "ManageAdversaries": "Manage Adversaries"
+    },
+    "Manager": {
+      "NoAdversariesUpdated": "No Adversaries updated.",
+      "SelectedAdversaries": "Selected Adversaries",
+      "SelectTargetTier": "Select Target Tier:"
+    },
+    "LiveManager": {
+      "AddExperience": "Add Experience",
+      "ClickImageOpenSheet": "Click image to open sheet",
+      "EditValues": "Edit values to override random rolls.",
+      "ErrorApplying": "Error applying changes. Check console.",
+      "ExpName": "Exp Name",
+      "FeatureChanges": "Feature Changes",
+      "Fixed": "Fixed",
+      "ImportApplyTier": "Import & Apply Tier {tier}",
+      "ItemNotFound": "Item not found or has no sheet.",
+      "MagicalDamage": "Magical Damage",
+      "MagShort": "Mag",
+      "MajorShort": "Maj",
+      "ManageCompendiums": "Manage Compendiums",
+      "NameForNewActor": "Name for new actor",
+      "NewActorName": "New Actor Name",
+      "NewAdversary": "New Adversary",
+      "NewExperience": "New Experience",
+      "NewFeatures": "New Features",
+      "NoChangesNecessary": "No changes were necessary.",
+      "NoModifiedFeatures": "No modified features.",
+      "OpenItem": "Open Item",
+      "OpenSheetAfterApplying": "Open sheet after applying",
+      "PhysicalDamage": "Physical Damage",
+      "PhysShort": "Phys",
+      "RollRandomName": "Roll Random Name",
+      "SelectAdversaryPrompt": "Select an Adversary from the list above to begin preview.",
+      "SevereShort": "Sev",
+      "SuggestedAmountModifier": "Suggested:<br>Amount: {amount}<br>Modifier: {modifier}",
+      "TargetTier": "Target Tier:",
+      "TokenSuffix": "Token",
+      "UnknownType": "Unknown Type",
+      "BenchmarkMissing": "Benchmark missing",
+      "ApplyTierToActor": "Apply Tier {tier} to {actor}",
+      "Minion": "Minion"
+    },
+    "CompendiumManager": {
+      "Actors": "Actors",
+      "ChooseCompendiums": "Choose compendiums to be used as sources.",
+      "NoActorCompendiums": "No other Actor compendiums found.",
+      "NoItemCompendiums": "No Item compendiums found.",
+      "SaveSelection": "Save Selection",
+      "SelectAvailableCompendiums": "Select Available Compendiums"
+    },
+    "CompendiumStats": {
+      "AdversaryType": "Adversary Type:",
+      "AttackMod": "Attack Mod",
+      "ClickDragFeature": "Click to view, Drag to Sheet",
+      "CouldNotFindSheet": "Could not find sheet for {feature}",
+      "DamageRolls": "Damage Rolls",
+      "HalvedDmg": "Halved Dmg",
+      "ManageStatSources": "Manage Stat Sources",
+      "QuantityTooltip": "Quantity (Min-Max) +Value Range",
+      "ReadingData": "Reading Compendium Data...",
+      "RefreshStats": "Refresh Stats",
+      "ThresholdMax": "Threshold Max",
+      "ThresholdMin": "Threshold Min"
+    },
+    "StatsManager": {
+      "FolderPlaceholder": "Folder (Def: Imported...)",
+      "Important": "Important:",
+      "ImportNote": "Selecting a new compendium will trigger an automated import process. Features from the selected actors will be copied to your world items.",
+      "SaveSelectionImport": "Save Selection & Import",
+      "SelectStatSources": "Select Stat Sources",
+      "TagPlaceholder": "Tag (Def: Label)",
+      "WaitImport": "Please wait for the import notification to finish."
+    },
+    "DiceProbability": {
+      "Adv": "Adv",
+      "Advantage": "Advantage",
+      "AdvantageD20": "Advantage (2d20 keep highest)",
+      "AdvDie": "Adv. Die",
+      "CriticalDoubles": "Critical (Doubles)",
+      "D20System": "D20 System",
+      "Dice": "Dice",
+      "Dis": "Dis",
+      "Disadvantage": "Disadvantage",
+      "DisadvantageD20": "Disadvantage (2d20 keep lowest)",
+      "DisDie": "Dis. Die",
+      "DualityDice": "Duality Dice",
+      "FailureChance": "Failure Chance",
+      "Modifier": "Modifier (+/-)",
+      "Norm": "Norm",
+      "Normal": "Normal",
+      "NormalD20": "Normal (1d20)",
+      "ProbabilityAnalysis": "Probability Analysis",
+      "Results": "Results",
+      "Roll": "Roll",
+      "RollType": "Roll Type",
+      "SendToChat": "Send to Chat",
+      "SuccessChance": "Success Chance"
+    },
+    "EncounterBuilder": {
+      "AddToEncounter": "Add to Encounter",
+      "AddUnits": "Add units from the library.",
+      "AutoFolder": "Mode: Auto-Generate Folder Name",
+      "BudgetLimit": "Budget Limit",
+      "ClearAll": "Clear All",
+      "Create": "Create",
+      "CreateAndPlaceInvisible": "Create & Place Invisible",
+      "CreateEncounter": "Create Encounter",
+      "CurrentCost": "Current Cost",
+      "DamageBoost": "Add +{die} Damage (Lowers Budget Limit)",
+      "EditLiveManager": "Edit in Live Manager",
+      "EncounterCreated": "Encounter created in: \"{folder}\". Check the Actor directory.",
+      "EncounterPlaced": "Encounter created and {count} tokens placed on scene (Hidden).",
+      "FailedCreate": "Failed to create encounter. Check console.",
+      "FailedPlace": "Failed to place encounter. Check console.",
+      "FearBudget": "Fear Budget:",
+      "FearHint": "Spending more Fear increases the perceived difficulty level.",
+      "FolderName": "Folder Name:",
+      "FolderPlaceholder": "e.g., Boss Fight Room 3",
+      "Library": "Library ({count})",
+      "ManualFolder": "Mode: Manual Folder Name",
+      "NoActiveScene": "No active scene to place tokens.",
+      "NoAdversariesFound": "No adversaries found.",
+      "NoAdversariesToCreate": "No adversaries in the encounter to create.",
+      "PartyTier": "Party Tier:",
+      "PCs": "# PCs:",
+      "SearchPlaceholder": "Search adversaries...",
+      "SynergyMomentum": "There are adversaries capable of gaining Fear.",
+      "SynergyRelentless": "There are adversaries that can be spotlighted multiple times per GM turn.",
+      "SynergySpotlighter": "There are adversaries capable of spotlighting other adversaries.",
+      "SynergySummoner": "There are adversaries capable of summoning other adversaries.",
+      "UntitledEncounter": "Untitled Encounter"
+    },
+    "Encounter": {
+      "Difficulty": {
+        "Balanced": "Balanced",
+        "Challenging": "Challenging",
+        "Deadly": "Deadly",
+        "Easy": "Easy",
+        "Hard": "Hard",
+        "OutOfTier": "Out of Tier",
+        "VeryEasy": "Very Easy"
+      },
+      "Fear": {
+        "Extreme": "Extreme (4-8 Fear)",
+        "High": "High (2-4 Fear)",
+        "Insane": "Insane (6-12 Fear)",
+        "Low": "Low (0-1 Fear)",
+        "Moderate": "Moderate (1-3 Fear)"
+      },
+      "Modifiers": {
+        "DamageBoost": "Damage Boost",
+        "EasierShorter": "Easier/Shorter",
+        "HarderLonger": "Harder/Longer",
+        "LowerTierUsed": "Lower Tier Used",
+        "NoMajorAdversaries": "No Major Adversaries",
+        "TwoPlusSolos": "2+ Solos"
+      }
+    },
+    "FeatureUpdater": {
+      "AdversaryType": "Adversary Type",
+      "ConfigureFlags": "2. Configure Flags",
+      "CouldNotResolveItem": "Could not resolve Item UUID.",
+      "CustomTag": "Custom Tag",
+      "CustomTagPlaceholder": "e.g. Core, Homebrew",
+      "DragFeature": "Drag a Feature from the World",
+      "DropFeature": "1. Drop Feature Here",
+      "FailedUpdate": "Failed to update item flags.",
+      "InvalidDrop": "Invalid drop data.",
+      "NoItemSelected": "No item selected.",
+      "PleaseDropItem": "Please drop an Item.",
+      "TargetTier": "Target Tier",
+      "UpdateFlags": "Update Feature Flags"
+    },
+    "DamageEngine": {
+      "AddedByLiveManager": "Added by Live Manager",
+      "Adjusted": "Adjusted",
+      "Alt": "Alt",
+      "AutoAddedByTierScaling": "Auto-Added by Tier Scaling",
+      "BatchUpdateTier": "Batch Update: Tier {tier}",
+      "ChanceToHit": "{chance}% chance to hit.",
+      "Diff": "Diff",
+      "DmgThresh": "Dmg Thresh",
+      "Experiences": "Experiences",
+      "MaxEvasion": "Max Evasion",
+      "MaxTrait": "Max Trait",
+      "MinEvasion": "Min Evasion",
+      "NameOverride": "Name Override",
+      "NameUpdate": "Name Update",
+      "NewExp": "New Exp",
+      "NewFeature": "New Feature",
+      "PCThresholdTooltip": "PC Hit Chance (2d12 + Trait vs Diff {difficulty}):\nStandard Trait (+{minBonus}): {minChance}%\nMax Trait (+{maxBonus}): {maxChance}%",
+      "Replaced": "Replaced {name}",
+      "SheetDmg": "Sheet Dmg",
+      "SheetDmgManual": "Sheet Dmg (Manual)",
+      "VsPcTierTooltip": "Vs PC Tier {tier} Evasion ({evasion}):\nMin Evasion: {maxChance}% chance to hit.\nMax Evasion: {minChance}% chance to hit."
+    },
+    "Importer": {
+      "CompendiumNotActor": "Compendium \"{compendium}\" is not an Actor compendium.",
+      "CompendiumNotFound": "Compendium \"{compendium}\" not found.",
+      "ImportedFrom": "Imported from {label}"
+    },
+    "Defaults": {
+      "ImportedAdversaries": "Imported Adversaries",
+      "MyEncounters": "My Encounters"
+    },
+    "Notifications": {
+      "BrokenToken": "Error: The token \"{token}\" references an Actor that no longer exists in the directory.",
+      "GmOnly": "Only a GM can use this feature."
+    },
+    "Packs": {
+      "AllFeatures": "All Features",
+      "CustomFeatures": "Custom Features",
+      "Macros": "Macros",
+      "Templates": "Templates"
+    },
+    "PackFolders": {
+      "AdversaryManager": "Adversary Manager"
+    }
+  }
+}

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -1,0 +1,347 @@
+{
+  "DHAM": {
+    "Common": {
+      "Adversaries": "Противники",
+      "Adversary": "Противник",
+      "AllSources": "Все источники",
+      "AllTiers": "Все ранги",
+      "AllTypes": "Все типы",
+      "ApplyChanges": "Применить изменения",
+      "AttackBonus": "Бонус атаки",
+      "AttackDamage": "Урон атаки",
+      "Base": "База: {base}",
+      "ChooseAdversary": "-- Выберите противника --",
+      "Compendium": "Компендиум",
+      "Critical": "Критический успех",
+      "CriticalThreshold": "Порог критического успеха",
+      "Current": "Текущее",
+      "DamageType": "Тип урона:",
+      "Difficulty": "Сложность",
+      "Direct": "Прямой:",
+      "DirectNo": "Прямой: нет",
+      "DirectYes": "Прямой: да",
+      "Experiences": "Опыт",
+      "Failure": "Провал",
+      "Feature": "Особенность",
+      "Features": "Особенности",
+      "HalvedDamageHorde": "Половинный урон (орда)",
+      "Homebrew": "Домашнее",
+      "HP": "ОЗ",
+      "Linked": "Связан",
+      "ManualOverride": "Ручное значение",
+      "Max": "Макс.",
+      "Mean": "Среднее",
+      "Min": "Мин.",
+      "No": "Нет",
+      "None": "Нет",
+      "Preview": "Предпросмотр",
+      "Recommended": "Рекомендуется",
+      "Remove": "Удалить",
+      "RenameFeature": "Переименовать особенность",
+      "Stress": "Стресс",
+      "Success": "Успех",
+      "Suggested": "Рекомендовано:",
+      "SystemCompendium": "Системный компендиум",
+      "Thresholds": "Пороги",
+      "Tier": "Ранг {tier}",
+      "Type": "Тип",
+      "Unlinked": "Не связан",
+      "World": "Мир",
+      "WorldActors": "Мир (актеры)",
+      "Yes": "Да"
+    },
+    "Settings": {
+      "AddFeatures": {
+        "Hint": "Если включено, при повышении ранга будут случайно предлагаться новые особенности.",
+        "Name": "Автоматически добавлять особенности при повышении ранга"
+      },
+      "ChatLog": {
+        "Hint": "Если включено, Мастеру отправляется шепот в чат при обновлении противника через менеджер.",
+        "Name": "Записывать изменения в чат"
+      },
+      "EncounterFolder": {
+        "Hint": "Имя корневой папки, в которой будут храниться сцены, созданные конструктором.",
+        "Name": "Имя папки сцен"
+      },
+      "ExtraCompendiums": {
+        "Name": "Дополнительные компендиумы (актеры)"
+      },
+      "FeatureCompendiums": {
+        "Name": "Компендиумы особенностей"
+      },
+      "ImportFolder": {
+        "Hint": "Имя папки, куда будут создаваться противники, импортированные из компендиумов.",
+        "Name": "Папка импорта из компендиума"
+      },
+      "StatsCompendiums": {
+        "Name": "Компендиумы статистики"
+      },
+      "SuggestFeatures": {
+        "Hint": "Если включено, в предпросмотре Live Manager показывается раздел новых предложенных особенностей.",
+        "Name": "Включить предложенные особенности"
+      },
+      "UpdateExp": {
+        "Hint": "Если включено, значения опыта будут увеличиваться или уменьшаться на 1 за каждое изменение ранга.",
+        "Name": "Автоматически обновлять опыт"
+      }
+    },
+    "Windows": {
+      "AdversaryLiveManager": "Live Manager противников",
+      "AdversaryManager": "Менеджер противников",
+      "CompendiumManager": "Управление источниками компендиумов",
+      "CompendiumStats": "Статистика компендиумов",
+      "DiceProbability": "Калькулятор вероятности броска",
+      "EncounterBuilder": "Конструктор сцен",
+      "EncounterName": "Название сцены",
+      "FeatureUpdater": "Редактор флагов особенностей",
+      "StatsManager": "Управление источниками статистики"
+    },
+    "ModuleMenu": {
+      "AdversaryTools": "Инструменты противников",
+      "CompendiumStats": "Статистика компендиума",
+      "DiceProbability": "Вероятность броска",
+      "EncounterBuilder": "Конструктор сцен",
+      "ManageAdversaries": "Управлять противниками"
+    },
+    "Manager": {
+      "NoAdversariesUpdated": "Противники не обновлены.",
+      "SelectedAdversaries": "Выбранные противники",
+      "SelectTargetTier": "Выберите целевой ранг:"
+    },
+    "LiveManager": {
+      "AddExperience": "Добавить опыт",
+      "ClickImageOpenSheet": "Нажмите на изображение, чтобы открыть лист",
+      "EditValues": "Измените значения, чтобы переопределить случайные броски.",
+      "ErrorApplying": "Ошибка при применении изменений. Проверьте консоль.",
+      "ExpName": "Название опыта",
+      "FeatureChanges": "Изменения особенностей",
+      "Fixed": "Фиксировано",
+      "ImportApplyTier": "Импортировать и применить ранг {tier}",
+      "ItemNotFound": "Предмет не найден или у него нет листа.",
+      "MagicalDamage": "Магический урон",
+      "MagShort": "Маг.",
+      "MajorShort": "Выс.",
+      "ManageCompendiums": "Управление компендиумами",
+      "NameForNewActor": "Имя нового актера",
+      "NewActorName": "Имя нового актера",
+      "NewAdversary": "Новый противник",
+      "NewExperience": "Новый опыт",
+      "NewFeatures": "Новые особенности",
+      "NoChangesNecessary": "Изменения не требуются.",
+      "NoModifiedFeatures": "Измененных особенностей нет.",
+      "OpenItem": "Открыть предмет",
+      "OpenSheetAfterApplying": "Открыть лист после применения",
+      "PhysicalDamage": "Физический урон",
+      "PhysShort": "Физ.",
+      "RollRandomName": "Случайное название",
+      "SelectAdversaryPrompt": "Выберите противника в списке выше, чтобы начать предпросмотр.",
+      "SevereShort": "Тяж.",
+      "SuggestedAmountModifier": "Рекомендовано:<br>Количество: {amount}<br>Модификатор: {modifier}",
+      "TargetTier": "Целевой ранг:",
+      "TokenSuffix": "токен",
+      "UnknownType": "Неизвестный тип",
+      "BenchmarkMissing": "Нет эталонных значений",
+      "ApplyTierToActor": "Применить ранг {tier} к {actor}",
+      "Minion": "Миньон"
+    },
+    "CompendiumManager": {
+      "Actors": "Актеры",
+      "ChooseCompendiums": "Выберите компендиумы, которые будут использоваться как источники.",
+      "NoActorCompendiums": "Другие компендиумы актеров не найдены.",
+      "NoItemCompendiums": "Компендиумы предметов не найдены.",
+      "SaveSelection": "Сохранить выбор",
+      "SelectAvailableCompendiums": "Выберите доступные компендиумы"
+    },
+    "CompendiumStats": {
+      "AdversaryType": "Тип противника:",
+      "AttackMod": "Мод. атаки",
+      "ClickDragFeature": "Нажмите, чтобы открыть; перетащите на лист",
+      "CouldNotFindSheet": "Не удалось найти лист для {feature}",
+      "DamageRolls": "Броски урона",
+      "HalvedDmg": "Половинный урон",
+      "HitPoints": "Очки здоровья",
+      "ManageStatSources": "Управление источниками статистики",
+      "QuantityTooltip": "Количество (мин.-макс.) + диапазон значения",
+      "ReadingData": "Чтение данных компендиумов...",
+      "RefreshStats": "Обновить статистику",
+      "ThresholdMax": "Макс. порог",
+      "ThresholdMin": "Мин. порог"
+    },
+    "StatsManager": {
+      "FolderPlaceholder": "Папка (по умолч.: Imported...)",
+      "Important": "Важно:",
+      "ImportNote": "Выбор нового компендиума запустит автоматический импорт. Особенности выбранных актеров будут скопированы в предметы мира.",
+      "SaveSelectionImport": "Сохранить выбор и импортировать",
+      "SelectStatSources": "Выберите источники статистики",
+      "TagPlaceholder": "Тег (по умолч.: Label)",
+      "WaitImport": "Дождитесь уведомления о завершении импорта."
+    },
+    "DiceProbability": {
+      "Adv": "Преим.",
+      "Advantage": "Преимущество",
+      "AdvantageD20": "Преимущество (2d20, оставить больший)",
+      "AdvDie": "Кость преим.",
+      "CriticalDoubles": "Крит (дубли)",
+      "D20System": "Система D20",
+      "Dice": "Кости",
+      "Dis": "Помеха",
+      "Disadvantage": "Помеха",
+      "DisadvantageD20": "Помеха (2d20, оставить меньший)",
+      "DisDie": "Кость помехи",
+      "DualityDice": "Кости двойственности",
+      "FailureChance": "Шанс провала",
+      "Modifier": "Модификатор (+/-)",
+      "Norm": "Норм.",
+      "Normal": "Обычный",
+      "NormalD20": "Обычный (1d20)",
+      "ProbabilityAnalysis": "Анализ вероятности",
+      "Results": "Результаты",
+      "Roll": "Бросок",
+      "RollType": "Тип броска",
+      "SendToChat": "Отправить в чат",
+      "SuccessChance": "Шанс успеха"
+    },
+    "EncounterBuilder": {
+      "AddToEncounter": "Добавить в сцену",
+      "AddUnits": "Добавьте существ из библиотеки.",
+      "AutoFolder": "Режим: автоматическое имя папки",
+      "BudgetLimit": "Лимит бюджета",
+      "ClearAll": "Очистить все",
+      "Create": "Создать",
+      "CreateAndPlaceInvisible": "Создать и разместить невидимо",
+      "CreateEncounter": "Создать сцену",
+      "CurrentCost": "Текущая стоимость",
+      "DamageBoost": "Добавить +{die} урона (снижает лимит бюджета)",
+      "EditLiveManager": "Редактировать в Live Manager",
+      "EncounterCreated": "Сцена создана в: \"{folder}\". Проверьте каталог актеров.",
+      "EncounterPlaced": "Сцена создана, и {count} токенов размещено на сцене (скрыто).",
+      "FailedCreate": "Не удалось создать сцену. Проверьте консоль.",
+      "FailedPlace": "Не удалось разместить сцену. Проверьте консоль.",
+      "FearBudget": "Бюджет страха:",
+      "FearHint": "Чем больше страха потрачено, тем выше воспринимаемая сложность.",
+      "FolderName": "Имя папки:",
+      "FolderPlaceholder": "например, Комната босса 3",
+      "Library": "Библиотека ({count})",
+      "ManualFolder": "Режим: ручное имя папки",
+      "NoActiveScene": "Нет активной сцены для размещения токенов.",
+      "NoAdversariesFound": "Противники не найдены.",
+      "NoAdversariesToCreate": "В сцене нет противников для создания.",
+      "PartyTier": "Ранг группы:",
+      "PCs": "# персонажей:",
+      "SearchPlaceholder": "Поиск противников...",
+      "SynergyMomentum": "Есть противники, способные получать страх.",
+      "SynergyRelentless": "Есть противники, которых можно выделять несколько раз за ход Мастера.",
+      "SynergySpotlighter": "Есть противники, способные выделять других противников.",
+      "SynergySummoner": "Есть противники, способные призывать других противников.",
+      "UntitledEncounter": "Безымянная сцена"
+    },
+    "Encounter": {
+      "Difficulty": {
+        "Balanced": "Сбалансировано",
+        "Challenging": "Сложно",
+        "Deadly": "Смертельно",
+        "Easy": "Легко",
+        "Hard": "Тяжело",
+        "OutOfTier": "Вне ранга",
+        "VeryEasy": "Очень легко"
+      },
+      "Fear": {
+        "Extreme": "Экстремально (4-8 страха)",
+        "High": "Высоко (2-4 страха)",
+        "Insane": "Безумно (6-12 страха)",
+        "Low": "Низко (0-1 страха)",
+        "Moderate": "Умеренно (1-3 страха)"
+      },
+      "Modifiers": {
+        "DamageBoost": "Усиление урона",
+        "EasierShorter": "Проще/короче",
+        "HarderLonger": "Сложнее/дольше",
+        "LowerTierUsed": "Использован нижний ранг",
+        "NoMajorAdversaries": "Нет крупных противников",
+        "TwoPlusSolos": "2+ одиночки"
+      }
+    },
+    "FeatureUpdater": {
+      "AdversaryType": "Тип противника",
+      "ConfigureFlags": "2. Настройте флаги",
+      "CouldNotResolveItem": "Не удалось определить UUID предмета.",
+      "CustomTag": "Пользовательский тег",
+      "CustomTagPlaceholder": "например, Core, Homebrew",
+      "DragFeature": "Перетащите особенность из мира",
+      "DropFeature": "1. Перетащите особенность сюда",
+      "FailedUpdate": "Не удалось обновить флаги предмета.",
+      "InvalidDrop": "Недопустимые данные перетаскивания.",
+      "NoItemSelected": "Предмет не выбран.",
+      "PleaseDropItem": "Перетащите предмет.",
+      "TargetTier": "Целевой ранг",
+      "UpdateFlags": "Обновить флаги особенности"
+    },
+    "DamageEngine": {
+      "AddedByLiveManager": "Добавлено через Live Manager",
+      "Adjusted": "скорректировано",
+      "Alt": "альт.",
+      "AutoAddedByTierScaling": "Автоматически добавлено при масштабировании ранга",
+      "BatchUpdateTier": "Пакетное обновление: ранг {tier}",
+      "ChanceToHit": "{chance}% шанс попасть.",
+      "Custom": "ручное",
+      "Diff": "Сложн.",
+      "DmgThresh": "Пороги урона",
+      "Experiences": "Опыт",
+      "MaxEvasion": "Макс. уклонение",
+      "MaxTrait": "Макс. черта",
+      "MinEvasion": "Мин. уклонение",
+      "NameOverride": "Ручное имя",
+      "NameUpdate": "Обновление имени",
+      "NewExp": "Новый опыт",
+      "NewFeature": "Новая особенность",
+      "PCThresholdTooltip": "Шанс попадания персонажа (2d12 + черта против сложности {difficulty}):\nСтандартная черта (+{minBonus}): {minChance}%\nМакс. черта (+{maxBonus}): {maxChance}%",
+      "Replaced": "заменено: {name}",
+      "SheetDmg": "Урон листа",
+      "SheetDmgManual": "Урон листа (ручной)",
+      "VsPcTierTooltip": "Против уклонения персонажей ранга {tier} ({evasion}):\nМин. уклонение: {maxChance}% шанс попасть.\nМакс. уклонение: {minChance}% шанс попасть."
+    },
+    "Importer": {
+      "Action": "Действие",
+      "CompendiumNotActor": "Компендиум \"{compendium}\" не является компендиумом актеров.",
+      "CompendiumNotFound": "Компендиум \"{compendium}\" не найден.",
+      "ImportedFrom": "Импортировано из {label}",
+      "Passive": "Пассивное",
+      "Reaction": "Реакция"
+    },
+    "Types": {
+      "bruiser": "Громила",
+      "horde": "Орда",
+      "leader": "Лидер",
+      "minion": "Миньон",
+      "ranged": "Дальнобойный",
+      "skulk": "Скрытень",
+      "social": "Социальный",
+      "solo": "Одиночка",
+      "standard": "Стандартный",
+      "support": "Поддержка",
+      "unknown": "Неизвестный"
+    },
+    "FeatureForms": {
+      "action": "Действие",
+      "passive": "Пассивное",
+      "reaction": "Реакция"
+    },
+    "Defaults": {
+      "ImportedAdversaries": "Импортированные противники",
+      "MyEncounters": "Мои сцены"
+    },
+    "Notifications": {
+      "BrokenToken": "Ошибка: токен \"{token}\" ссылается на актера, которого больше нет в каталоге.",
+      "GmOnly": "Эта функция доступна только Мастеру."
+    },
+    "Packs": {
+      "AllFeatures": "Все особенности",
+      "CustomFeatures": "Пользовательские особенности",
+      "Macros": "Макросы",
+      "Templates": "Шаблоны"
+    },
+    "PackFolders": {
+      "AdversaryManager": "Менеджер противников"
+    }
+  }
+}

--- a/module.json
+++ b/module.json
@@ -1,7 +1,8 @@
 {
   "id": "daggerheart-advmanager",
+  "type": "module",
   "title": "Daggerheart: Adversary Manager",
-  "version": "0.2.7",
+  "version": "0.2.8",
   
   "description": "The ultimate GM companion for **Daggerheart** in Foundry VTT. Scale adversaries instantly, build balanced encounters.",
 
@@ -12,9 +13,9 @@
 	}], 
   
   "compatibility": {
-    "minimum": 13,
-    "verified": 13,
-    "maximum": 13
+    "minimum": "14.359",
+    "verified": "14.360",
+    "maximum": 14
   },
   "authors": [
     {
@@ -29,7 +30,8 @@
         "id": "daggerheart",
         "type": "system",
         "compatibility": {
-          "minimum": "1.4.4"
+          "minimum": "2.0.0",
+          "verified": "2"
         }
       }
     ]

--- a/module.json
+++ b/module.json
@@ -39,7 +39,7 @@
 
   "packs": [
     {
-      "label": "Custom Features",
+      "label": "DHAM.Packs.CustomFeatures",
       "type": "Item",
       "name": "custom-features",
       "path": "packs/custom-features",
@@ -52,7 +52,7 @@
       "banner": "modules/daggerheart-advmanager/assets/images/banner.webp" 
     },    
     {
-      "label": "All Features",
+      "label": "DHAM.Packs.AllFeatures",
       "type": "Item",
       "name": "all-features",
       "path": "packs/all-features",
@@ -65,7 +65,7 @@
       "banner": "modules/daggerheart-advmanager/assets/images/banner.webp" 
     },
     {
-      "label": "Macros",
+      "label": "DHAM.Packs.Macros",
       "type": "Macro",
       "name": "macros",
       "path": "packs/macros",
@@ -78,7 +78,7 @@
       "banner": "modules/daggerheart-advmanager/assets/images/banner.webp" 
     },
     {
-      "label": "Templates",
+      "label": "DHAM.Packs.Templates",
       "type": "Actor",
       "name": "templates",
       "path": "packs/templates",
@@ -94,7 +94,7 @@
 
   "packFolders": [
     {
-      "name": "💀 Adversary Manager 💀",
+      "name": "DHAM.PackFolders.AdversaryManager",
       "sorting": "a",
       "color": "#5c0547",
       "packs": [        
@@ -109,6 +109,18 @@
   
   "esmodules": ["scripts/module.js"],
   "styles": ["styles/style.css"],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json"
+    },
+    {
+      "lang": "ru",
+      "name": "Русский",
+      "path": "lang/ru.json"
+    }
+  ],
   
   "url": "https://github.com/brunocalado/daggerheart-advmanager",
   "manifest": "https://raw.githubusercontent.com/brunocalado/daggerheart-advmanager/main/module.json",

--- a/scripts/compendium-manager.js
+++ b/scripts/compendium-manager.js
@@ -10,7 +10,7 @@ export class CompendiumManager extends HandlebarsApplicationMixin(ApplicationV2)
         id: "daggerheart-compendium-manager",
         tag: "form",
         window: {
-            title: "Manage Compendium Sources",
+            title: "DHAM.Windows.CompendiumManager",
             icon: "fas fa-atlas",
             resizable: false,
             width: 450,

--- a/scripts/compendium-stats-manager.js
+++ b/scripts/compendium-stats-manager.js
@@ -1,5 +1,6 @@
 import { MODULE_ID, SETTING_STATS_COMPENDIUMS } from "./module.js";
 import { findApplicationById } from "./foundry-compat.js";
+import { localize } from "./i18n.js";
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 /**
@@ -12,7 +13,7 @@ export class CompendiumStatsManager extends HandlebarsApplicationMixin(Applicati
         id: "daggerheart-stats-manager",
         tag: "form",
         window: {
-            title: "Manage Stat Sources",
+            title: "DHAM.Windows.StatsManager",
             icon: "fas fa-chart-pie",
             resizable: false,
             width: 700, // Increased width to fit new inputs
@@ -100,7 +101,7 @@ export class CompendiumStatsManager extends HandlebarsApplicationMixin(Applicati
 
                     const finalFolder = customFolderInput && customFolderInput.trim() !== "" 
                         ? customFolderInput.trim() 
-                        : `Imported from ${defaultLabel}`;
+                        : localize("Importer.ImportedFrom", { label: defaultLabel });
                     
                     // Execute import using the exposed global function
                     if (globalThis.AM && globalThis.AM.ImportFeatures) {

--- a/scripts/compendium-stats-manager.js
+++ b/scripts/compendium-stats-manager.js
@@ -1,4 +1,5 @@
 import { MODULE_ID, SETTING_STATS_COMPENDIUMS } from "./module.js";
+import { findApplicationById } from "./foundry-compat.js";
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 /**
@@ -114,7 +115,7 @@ export class CompendiumStatsManager extends HandlebarsApplicationMixin(Applicati
         console.log("Adversary Manager | Stat sources updated.");
         
         // 5. Reload Stats Window if open
-        const statsApp = Object.values(ui.windows).find(w => w.id === "daggerheart-compendium-stats");
+        const statsApp = findApplicationById("daggerheart-compendium-stats");
         if (statsApp) {
             statsApp.loading = true;
             statsApp.render();

--- a/scripts/compendium-stats.js
+++ b/scripts/compendium-stats.js
@@ -2,6 +2,7 @@ const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 import { CompendiumStatsManager } from "./compendium-stats-manager.js";
 import { MODULE_ID, SETTING_STATS_COMPENDIUMS } from "./module.js";
 import { getDamagePartsArray } from "./damage-engine.js";
+import { localize, localizeType } from "./i18n.js";
 
 export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
     
@@ -18,7 +19,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
         id: "daggerheart-compendium-stats",
         tag: "div",
         window: {
-            title: "Compendium Statistics",
+            title: "DHAM.Windows.CompendiumStats",
             icon: "fas fa-chart-bar",
             resizable: true,
             width: 900,
@@ -47,7 +48,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
         const types = new Set(this.allActors.map(a => a.system.type?.toLowerCase() || "standard"));
         const typeOptions = Array.from(types).sort().map(t => ({
             value: t,
-            label: t.charAt(0).toUpperCase() + t.slice(1),
+            label: localizeType(t),
             selected: t === this.selectedType
         }));
 
@@ -57,7 +58,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
             loading: this.loading,
             typeOptions: typeOptions,
             stats: statsData,
-            headers: ["Tier 1", "Tier 2", "Tier 3", "Tier 4"]
+            headers: [1, 2, 3, 4].map(t => localize("Common.Tier", { tier: t }))
         };
     }
 
@@ -85,7 +86,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
                 
                 // Fallback (apenas se UUID falhar)
                 const featureName = link.dataset.featureName;
-                ui.notifications.warn(`Could not find sheet for ${featureName}`);
+                ui.notifications.warn(localize("CompendiumStats.CouldNotFindSheet", { feature: featureName }));
             });
 
             link.addEventListener('dragstart', (e) => {
@@ -275,18 +276,18 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
 
     _formatStatsRows(data, type) {
         const rows = [
-            { label: "Difficulty", t1: this._getRange(data[1].difficulty), t2: this._getRange(data[2].difficulty), t3: this._getRange(data[3].difficulty), t4: this._getRange(data[4].difficulty) },
-            { label: "Threshold Min", t1: this._getRange(data[1].major), t2: this._getRange(data[2].major), t3: this._getRange(data[3].major), t4: this._getRange(data[4].major) },
-            { label: "Threshold Max", t1: this._getRange(data[1].severe), t2: this._getRange(data[2].severe), t3: this._getRange(data[3].severe), t4: this._getRange(data[4].severe) },
-            { label: "Hit Points", t1: this._getRange(data[1].hp), t2: this._getRange(data[2].hp), t3: this._getRange(data[3].hp), t4: this._getRange(data[4].hp) },
-            { label: "Stress", t1: this._getRange(data[1].stress), t2: this._getRange(data[2].stress), t3: this._getRange(data[3].stress), t4: this._getRange(data[4].stress) },
-            { label: "Attack Mod", t1: this._getSignedRange(data[1].attackMod), t2: this._getSignedRange(data[2].attackMod), t3: this._getSignedRange(data[3].attackMod), t4: this._getSignedRange(data[4].attackMod) },
-            { label: "Damage Rolls", t1: this._getList(data[1].damageRolls), t2: this._getList(data[2].damageRolls), t3: this._getList(data[3].damageRolls), t4: this._getList(data[4].damageRolls), isList: true }
+            { label: localize("Common.Difficulty"), t1: this._getRange(data[1].difficulty), t2: this._getRange(data[2].difficulty), t3: this._getRange(data[3].difficulty), t4: this._getRange(data[4].difficulty) },
+            { label: localize("CompendiumStats.ThresholdMin"), t1: this._getRange(data[1].major), t2: this._getRange(data[2].major), t3: this._getRange(data[3].major), t4: this._getRange(data[4].major) },
+            { label: localize("CompendiumStats.ThresholdMax"), t1: this._getRange(data[1].severe), t2: this._getRange(data[2].severe), t3: this._getRange(data[3].severe), t4: this._getRange(data[4].severe) },
+            { label: localize("CompendiumStats.HitPoints"), t1: this._getRange(data[1].hp), t2: this._getRange(data[2].hp), t3: this._getRange(data[3].hp), t4: this._getRange(data[4].hp) },
+            { label: localize("Common.Stress"), t1: this._getRange(data[1].stress), t2: this._getRange(data[2].stress), t3: this._getRange(data[3].stress), t4: this._getRange(data[4].stress) },
+            { label: localize("CompendiumStats.AttackMod"), t1: this._getSignedRange(data[1].attackMod), t2: this._getSignedRange(data[2].attackMod), t3: this._getSignedRange(data[3].attackMod), t4: this._getSignedRange(data[4].attackMod) },
+            { label: localize("CompendiumStats.DamageRolls"), t1: this._getList(data[1].damageRolls), t2: this._getList(data[2].damageRolls), t3: this._getList(data[3].damageRolls), t4: this._getList(data[4].damageRolls), isList: true }
         ];
 
         if (type === "horde") {
             rows.push({ 
-                label: "Halved Dmg", 
+                label: localize("CompendiumStats.HalvedDmg"),
                 t1: this._getList(data[1].halvedDamageRolls), 
                 t2: this._getList(data[2].halvedDamageRolls), 
                 t3: this._getList(data[3].halvedDamageRolls), 
@@ -296,7 +297,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
         }
 
         rows.push({
-            label: "Experiences",
+            label: localize("Common.Experiences"),
             t1: this._formatExpData(data[1]),
             t2: this._formatExpData(data[2]),
             t3: this._formatExpData(data[3]),
@@ -304,7 +305,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
         });
 
         rows.push({
-            label: "Features",
+            label: localize("Common.Features"),
             t1: this._getFeatureList(data[1].features),
             t2: this._getFeatureList(data[2].features),
             t3: this._getFeatureList(data[3].features),
@@ -363,7 +364,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
             if (minVal === maxVal) valStr = fmt(minVal);
             else valStr = `${fmt(minVal)}/${fmt(maxVal)}`;
         }
-        const tooltip = "Quantity (Min-Max) +Value Range";
+        const tooltip = localize("CompendiumStats.QuantityTooltip");
         return `<span data-tooltip="${tooltip}" style="cursor: help;">${countStr} ${valStr}</span>`;
     }
 
@@ -380,7 +381,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
             const draggableAttr = data.uuid ? `draggable="true" data-uuid="${data.uuid}"` : "";
             const displayLabel = data.typeLabel ? `<span style="opacity: 0.7; margin-left: 4px;">${data.typeLabel}</span>` : "";
             
-            return `<div class="feature-entry feature-link" data-feature-name="${name}" ${draggableAttr} title="Click to view, Drag to Sheet">
+            return `<div class="feature-entry feature-link" data-feature-name="${name}" ${draggableAttr} title="${localize("CompendiumStats.ClickDragFeature")}">
                 <img src="${data.img}" class="feature-icon" alt="${name}"/>
                 <span class="feature-name">${name}${displayLabel}</span>
              </div>`

--- a/scripts/compendium-stats.js
+++ b/scripts/compendium-stats.js
@@ -1,6 +1,7 @@
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 import { CompendiumStatsManager } from "./compendium-stats-manager.js";
 import { MODULE_ID, SETTING_STATS_COMPENDIUMS } from "./module.js";
+import { getDamagePartsArray } from "./damage-engine.js";
 
 export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
     
@@ -200,7 +201,7 @@ export class CompendiumStats extends HandlebarsApplicationMixin(ApplicationV2) {
 
                 // --- Damage ---
                 if (sys.attack?.damage?.parts) {
-                    sys.attack.damage.parts.forEach(part => {
+                    getDamagePartsArray(sys.attack.damage.parts).forEach(part => {
                         let formula = this._extractFormula(part.value);
                         if (formula) data[actorTier].damageRolls.add(formula);
 

--- a/scripts/damage-engine.js
+++ b/scripts/damage-engine.js
@@ -8,6 +8,7 @@
 import { ADVERSARY_BENCHMARKS, PC_BENCHMARKS, ADVERSARY_EXPERIENCES } from "./rules.js";
 import { MODULE_ID, SETTING_CHAT_LOG, SETTING_UPDATE_EXP, SETTING_ADD_FEATURES, SKULL_IMAGE_PATH } from "./module.js";
 import { prepareDocumentCreateData } from "./foundry-compat.js";
+import { localize } from "./i18n.js";
 
 // --- Utility Parsers ---
 
@@ -151,8 +152,8 @@ export function calculateHitChance(attackBonus, tier) {
     const minChance = calculateChance(worstCaseTarget);
 
     return {
-        text: `(Min: ${minChance}% | Max: ${maxChance}%)`,
-        tooltip: `Vs PC Tier ${tier} Evasion (${pcStats.evasion}):\nMin Evasion: ${maxChance}% chance to hit.\nMax Evasion: ${minChance}% chance to hit.`
+        text: `(${localize("Common.Min")}: ${minChance}% | ${localize("Common.Max")}: ${maxChance}%)`,
+        tooltip: localize("DamageEngine.VsPcTierTooltip", { tier, evasion: pcStats.evasion, maxChance, minChance })
     };
 }
 
@@ -191,8 +192,8 @@ export function calculateHitChanceAgainst(difficulty, tier) {
     const maxChance = calculate(maxBonus);
 
     return {
-        text: `(Min: ${minChance}% | Max: ${maxChance}%)`,
-        tooltip: `PC Hit Chance (2d12 + Trait vs Diff ${difficulty}):\nStandard Trait (+${minBonus}): ${minChance}%\nMax Trait (+${maxBonus}): ${maxChance}%`
+        text: `(${localize("Common.Min")}: ${minChance}% | ${localize("Common.Max")}: ${maxChance}%)`,
+        tooltip: localize("DamageEngine.PCThresholdTooltip", { difficulty, minBonus, minChance, maxBonus, maxChance })
     };
 }
 
@@ -517,7 +518,7 @@ export function processFeatureUpdate(itemData, newTier, currentTier, benchmark, 
                 }
                 result.changes.forEach(c => {
                     if (!c.unchanged) {
-                        const customLabel = c.isCustom ? " (Custom)" : "";
+                        const customLabel = c.isCustom ? ` (${localize("DamageEngine.Custom")})` : "";
                         const altLabel = c.labelSuffix || "";
                         const logMsg = `<strong>${itemData.name}:</strong> ${c.from} -> ${c.to}${customLabel}${altLabel}`;
                         changeLog.push(logMsg);
@@ -545,7 +546,7 @@ export function processFeatureUpdate(itemData, newTier, currentTier, benchmark, 
     if (nameOverrides && nameOverrides[itemData._id]) {
         newName = nameOverrides[itemData._id];
         if (newName !== itemData.name) {
-            changeLog.push(`<strong>Name Override:</strong> ${itemData.name} -> ${newName}`);
+            changeLog.push(`<strong>${localize("DamageEngine.NameOverride")}:</strong> ${itemData.name} -> ${newName}`);
             hasChanges = true;
 
             const isMinion = newName.match(/^Minion\s*\((\d+)\)$/i);
@@ -623,7 +624,7 @@ export function processFeatureUpdate(itemData, newTier, currentTier, benchmark, 
             if (newDmgStr) {
                 newName = `Horde (${newDmgStr})`;
                 if (itemData.name !== newName) {
-                    changeLog.push(`<strong>Name Update:</strong> ${itemData.name} -> ${newName}`);
+                    changeLog.push(`<strong>${localize("DamageEngine.NameUpdate")}:</strong> ${itemData.name} -> ${newName}`);
                     hasChanges = true;
                     structuredChanges.push({
                         itemId: itemData._id,
@@ -666,7 +667,7 @@ export function processFeatureUpdate(itemData, newTier, currentTier, benchmark, 
                 newName = `Minion (${newVal})`;
                 minionVal = newVal;
                 if (itemData.name !== newName) {
-                    changeLog.push(`<strong>Name Update:</strong> ${itemData.name} -> ${newName}`);
+                    changeLog.push(`<strong>${localize("DamageEngine.NameUpdate")}:</strong> ${itemData.name} -> ${newName}`);
                     hasChanges = true;
                     structuredChanges.push({
                         itemId: itemData._id,
@@ -847,12 +848,12 @@ export async function handleNewFeatures(actor, typeKey, newTier, currentTier, ch
             const existingRelentless = currentItems.find(i => i.name.match(/^Relentless\s*\((\d+)\)$/i));
             if (existingRelentless) {
                 toDelete.push(existingRelentless.id);
-                changeLog.push(`<strong>New Feature:</strong> ${featureName} (Replaced ${existingRelentless.name})`);
+                changeLog.push(`<strong>${localize("DamageEngine.NewFeature")}:</strong> ${featureName} (${localize("DamageEngine.Replaced", { name: existingRelentless.name })})`);
             } else {
-                changeLog.push(`<strong>New Feature:</strong> ${featureName}`);
+                changeLog.push(`<strong>${localize("DamageEngine.NewFeature")}:</strong> ${featureName}`);
             }
         } else {
-            changeLog.push(`<strong>New Feature:</strong> ${featureName}`);
+            changeLog.push(`<strong>${localize("DamageEngine.NewFeature")}:</strong> ${featureName}`);
         }
     }
 
@@ -897,13 +898,13 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
 
     // 2. Update Stats (With Overrides)
     const diff = overrides.difficulty !== undefined ? Number(overrides.difficulty) : getRollFromRange(benchmark.difficulty);
-    if (diff) { updateData["system.difficulty"] = diff; statsLog.push(`<strong>Diff:</strong> ${actorData.system.difficulty} -> ${diff}`); }
+    if (diff) { updateData["system.difficulty"] = diff; statsLog.push(`<strong>${localize("DamageEngine.Diff")}:</strong> ${actorData.system.difficulty} -> ${diff}`); }
 
     const hp = overrides.hp !== undefined ? Number(overrides.hp) : getRollFromRange(benchmark.hp);
-    if (hp) { updateData["system.resources.hitPoints.max"] = hp; updateData["system.resources.hitPoints.value"] = 0; statsLog.push(`<strong>HP:</strong> ${actorData.system.resources.hitPoints.max} -> ${hp}`); }
+    if (hp) { updateData["system.resources.hitPoints.max"] = hp; updateData["system.resources.hitPoints.value"] = 0; statsLog.push(`<strong>${localize("Common.HP")}:</strong> ${actorData.system.resources.hitPoints.max} -> ${hp}`); }
 
     const stress = overrides.stress !== undefined ? Number(overrides.stress) : getRollFromRange(benchmark.stress);
-    if (stress) { updateData["system.resources.stress.max"] = stress; statsLog.push(`<strong>Stress:</strong> ${actorData.system.resources.stress.max} -> ${stress}`); }
+    if (stress) { updateData["system.resources.stress.max"] = stress; statsLog.push(`<strong>${localize("Common.Stress")}:</strong> ${actorData.system.resources.stress.max} -> ${stress}`); }
 
     if (benchmark.threshold_min && benchmark.threshold_max) {
         let major, severe;
@@ -920,7 +921,7 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
         if (major && severe) {
             updateData["system.damageThresholds.major"] = major;
             updateData["system.damageThresholds.severe"] = severe;
-            statsLog.push(`<strong>Dmg Thresh:</strong> ${actorData.system.damageThresholds.major}/${actorData.system.damageThresholds.severe} -> ${major}/${severe}`);
+            statsLog.push(`<strong>${localize("DamageEngine.DmgThresh")}:</strong> ${actorData.system.damageThresholds.major}/${actorData.system.damageThresholds.severe} -> ${major}/${severe}`);
         }
     }
 
@@ -929,7 +930,7 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
         updateData["system.attack.roll.bonus"] = atkMod;
         const oldAtk = actorData.system.attack.roll.bonus;
         const sign = atkMod >= 0 ? "+" : "";
-        statsLog.push(`<strong>Atk Mod:</strong> ${oldAtk} -> ${sign}${atkMod}`);
+        statsLog.push(`<strong>${localize("CompendiumStats.AttackMod")}:</strong> ${oldAtk} -> ${sign}${atkMod}`);
     }
 
     // 3. Update Sheet Damage (Main Attack)
@@ -954,7 +955,7 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
                         part.value.bonus = parsed.bonus;
                     }
                     updateData["system.attack.damage.parts"] = sheetDamageParts;
-                    statsLog.push(`<strong>Sheet Dmg (Manual):</strong> ${overrides.damageFormula}`);
+                    statsLog.push(`<strong>${localize("DamageEngine.SheetDmgManual")}:</strong> ${overrides.damageFormula}`);
                 }
             }
         }
@@ -982,7 +983,7 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
         if (result.hasChanges) {
             updateData["system.attack.damage.parts"] = sheetDamageParts;
             result.changes.forEach(c => {
-                statsLog.push(`<strong>Sheet Dmg:</strong> ${c.from} -> ${c.to}`);
+                statsLog.push(`<strong>${localize("DamageEngine.SheetDmg")}:</strong> ${c.from} -> ${c.to}`);
                 if (c.labelSuffix === " (Alt)" && !overrides.halvedDamageFormula) {
                      calculatedHalvedDamage = c.to;
                 }
@@ -1068,9 +1069,9 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
              if (!currentExperiences[tempId] && !data.deleted) {
                  const newId = foundry.utils.randomID();
                  updateData[`system.experiences.${newId}`] = {
-                     name: data.name || "New Experience",
+                     name: data.name || localize("LiveManager.NewExperience"),
                      value: data.value !== undefined ? data.value : targetMod,
-                     description: "Added by Live Manager"
+                     description: localize("DamageEngine.AddedByLiveManager")
                  };
                  manualAddedCount++;
              }
@@ -1096,7 +1097,7 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
 
             for (let i = 0; i < needed; i++) {
                 const newId = foundry.utils.randomID();
-                let name = "New Experience";
+                let name = localize("LiveManager.NewExperience");
                 if (availableNames.length > 0) {
                     const idx = Math.floor(Math.random() * availableNames.length);
                     name = availableNames[idx];
@@ -1105,13 +1106,13 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
                 updateData[`system.experiences.${newId}`] = {
                     name: name,
                     value: targetMod,
-                    description: "Auto-Added by Tier Scaling"
+                    description: localize("DamageEngine.AutoAddedByTierScaling")
                 };
-                statsLog.push(`<strong>New Exp:</strong> ${name}`);
+                statsLog.push(`<strong>${localize("DamageEngine.NewExp")}:</strong> ${name}`);
             }
         }
         if (currentCount !== keysToKeep.length || manualAddedCount > 0) {
-             statsLog.push(`<strong>Experiences:</strong> Adjusted`);
+             statsLog.push(`<strong>${localize("Common.Experiences")}:</strong> ${localize("DamageEngine.Adjusted")}`);
         }
     }
 
@@ -1245,6 +1246,6 @@ export function sendBatchChatLog(results, targetTier) {
         if (res.featureLog.length > 0) res.featureLog.forEach(log => { actorBlock += `<div style="font-size: 0.9em; margin-left: 5px;">• ${log}</div>`; });
         consolidatedContent += actorBlock + (index < results.length - 1 ? `<hr style="border: 0; border-top: 1px solid rgba(201, 160, 96, 0.5); margin: 8px 0;">` : "");
     });
-    const finalHtml = `<div class="chat-card" style="border: 2px solid #C9A060; border-radius: 8px; overflow: hidden;"><header class="card-header flexrow" style="background: #191919 !important; padding: 8px; border-bottom: 2px solid #C9A060;"><h3 class="noborder" style="margin: 0; font-weight: bold; color: #C9A060 !important; font-family: 'Aleo', serif; text-align: center; text-transform: uppercase; letter-spacing: 1px; width: 100%;">Batch Update: Tier ${targetTier}</h3></header><div class="card-content" style="background-image: url('${bgImage}'); background-repeat: no-repeat; background-position: center; background-size: cover; padding: 20px; min-height: 150px; display: flex; align-items: center; justify-content: center; text-align: center; position: relative;"><div style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.8); z-index: 0;"></div><span style="color: #ffffff !important; font-size: 1.0em; text-shadow: 0px 0px 8px #000000; position: relative; z-index: 1; font-family: 'Lato', sans-serif; line-height: 1.4; width: 100%; text-align: left;">${consolidatedContent}</span></div></div>`;
-    ChatMessage.create({ content: finalHtml, whisper: ChatMessage.getWhisperRecipients("GM"), speaker: ChatMessage.getSpeaker({ alias: "Adversary Manager" }) });
+    const finalHtml = `<div class="chat-card" style="border: 2px solid #C9A060; border-radius: 8px; overflow: hidden;"><header class="card-header flexrow" style="background: #191919 !important; padding: 8px; border-bottom: 2px solid #C9A060;"><h3 class="noborder" style="margin: 0; font-weight: bold; color: #C9A060 !important; font-family: 'Aleo', serif; text-align: center; text-transform: uppercase; letter-spacing: 1px; width: 100%;">${localize("DamageEngine.BatchUpdateTier", { tier: targetTier })}</h3></header><div class="card-content" style="background-image: url('${bgImage}'); background-repeat: no-repeat; background-position: center; background-size: cover; padding: 20px; min-height: 150px; display: flex; align-items: center; justify-content: center; text-align: center; position: relative;"><div style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.8); z-index: 0;"></div><span style="color: #ffffff !important; font-size: 1.0em; text-shadow: 0px 0px 8px #000000; position: relative; z-index: 1; font-family: 'Lato', sans-serif; line-height: 1.4; width: 100%; text-align: left;">${consolidatedContent}</span></div></div>`;
+    ChatMessage.create({ content: finalHtml, whisper: ChatMessage.getWhisperRecipients("GM"), speaker: ChatMessage.getSpeaker({ alias: localize("Windows.AdversaryManager") }) });
 }

--- a/scripts/damage-engine.js
+++ b/scripts/damage-engine.js
@@ -7,6 +7,7 @@
  */
 import { ADVERSARY_BENCHMARKS, PC_BENCHMARKS, ADVERSARY_EXPERIENCES } from "./rules.js";
 import { MODULE_ID, SETTING_CHAT_LOG, SETTING_UPDATE_EXP, SETTING_ADD_FEATURES, SKULL_IMAGE_PATH } from "./module.js";
+import { prepareDocumentCreateData } from "./foundry-compat.js";
 
 // --- Utility Parsers ---
 
@@ -198,6 +199,23 @@ export function calculateHitChanceAgainst(difficulty, tier) {
 // --- Core Damage Logic ---
 
 /**
+ * Normalizes Foundry damage parts to an iterable array without changing the
+ * original container shape. Daggerheart data may store parts as an Array or as
+ * an object keyed by part id/index.
+ * @param {Array|Object|null|undefined} parts - Raw damage parts container.
+ * @returns {Array} Damage part objects.
+ */
+export function getDamagePartsArray(parts) {
+    const isDamagePart = part => part && typeof part === "object" && ("value" in part || "valueAlt" in part || "type" in part);
+    if (Array.isArray(parts)) return parts.filter(isDamagePart);
+    if (parts && typeof parts === "object") {
+        if (isDamagePart(parts)) return [parts];
+        return Object.values(parts).filter(isDamagePart);
+    }
+    return [];
+}
+
+/**
  * Selects the best matching damage formula from the benchmark list for the new tier.
  * @param {string|null} currentDie - Current die type (e.g. "d8") or null for flat damage.
  * @param {number} currentBonus - Current bonus value.
@@ -334,7 +352,7 @@ export function processDamageValue(val, newTier, currentTier, damageRolls) {
 /**
  * Iterates all damage parts of an attack, applying auto-scaling or forced overrides.
  * Handles Minion flat-damage and Horde halved-damage paths.
- * @param {Array} parts - Array of damage part objects.
+ * @param {Array|Object} parts - Damage part objects as an array or keyed object.
  * @param {number} newTier - Target tier.
  * @param {number} currentTier - Current tier.
  * @param {Object} benchmark - Tier benchmark data.
@@ -344,14 +362,15 @@ export function processDamageValue(val, newTier, currentTier, damageRolls) {
 export function updateDamageParts(parts, newTier, currentTier, benchmark, forceFormula = null) {
     let hasChanges = false;
     const changes = [];
+    const damageParts = getDamagePartsArray(parts);
 
-    if (!parts || !Array.isArray(parts)) return { hasChanges, changes };
+    if (!damageParts.length) return { hasChanges, changes };
 
     // Handle Legacy String Override (Applies to first part only)
     if (typeof forceFormula === 'string' && forceFormula) {
         const parsed = parseDamageString(forceFormula);
         if (parsed) {
-            const part = parts.find(p => p.value);
+            const part = damageParts.find(p => p.value);
             if (part) {
                 let oldFormula = part.value.custom?.enabled ? part.value.custom.formula : (part.value.dice ? `${part.value.flatMultiplier}${part.value.dice}` : `${part.value.flatMultiplier}`);
 
@@ -377,7 +396,7 @@ export function updateDamageParts(parts, newTier, currentTier, benchmark, forceF
     }
 
     // Standard logic with Multipart Override Support (Object Map)
-    parts.forEach(part => {
+    damageParts.forEach(part => {
         // MINION CHECK: If benchmark has 'basic_attack_y', use it instead of scaling
         if (benchmark.basic_attack_y && part.value) {
             const currentFormula = part.value.custom?.enabled ? part.value.custom.formula : `${part.value.flatMultiplier}`;
@@ -783,7 +802,7 @@ export async function handleNewFeatures(actor, typeKey, newTier, currentTier, ch
 
             if (entry) {
                 const doc = await pack.getDocument(entry._id);
-                featureData = doc.toObject();
+                featureData = prepareDocumentCreateData(doc, game.items);
                 sourceUuid = doc.uuid;
                 break;
             }
@@ -800,7 +819,7 @@ export async function handleNewFeatures(actor, typeKey, newTier, currentTier, ch
                     const templateEntry = index.find(e => e.name === "Minion (X)");
                     if (templateEntry) {
                         const doc = await customPack.getDocument(templateEntry._id);
-                        featureData = doc.toObject();
+                        featureData = prepareDocumentCreateData(doc, game.items);
                         sourceUuid = doc.uuid;
 
                         featureData.name = featureName;
@@ -818,9 +837,7 @@ export async function handleNewFeatures(actor, typeKey, newTier, currentTier, ch
             continue;
         }
 
-        if (sourceUuid) {
-            featureData.uuid = sourceUuid;
-        }
+        if (sourceUuid) foundry.utils.setProperty(featureData, "flags.core.sourceId", sourceUuid);
 
         toCreate.push(featureData);
 
@@ -920,11 +937,12 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
 
     if (actorData.system.attack && actorData.system.attack.damage && actorData.system.attack.damage.parts) {
         const sheetDamageParts = foundry.utils.deepClone(actorData.system.attack.damage.parts);
+        const sheetDamagePartList = getDamagePartsArray(sheetDamageParts);
 
-        if (overrides.damageFormula && sheetDamageParts.length > 0) {
+        if (overrides.damageFormula && sheetDamagePartList.length > 0) {
             const parsed = parseDamageString(overrides.damageFormula);
             if (parsed) {
-                const part = sheetDamageParts[0];
+                const part = sheetDamagePartList[0];
                 if (part.value) {
                     if (parsed.die === null) {
                         part.value.flatMultiplier = parsed.count;
@@ -941,11 +959,11 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
             }
         }
 
-        if (overrides.halvedDamageFormula && sheetDamageParts.length > 0) {
+        if (overrides.halvedDamageFormula && sheetDamagePartList.length > 0) {
              calculatedHalvedDamage = overrides.halvedDamageFormula;
              const parsed = parseDamageString(overrides.halvedDamageFormula);
-             if (parsed && sheetDamageParts[0].valueAlt) {
-                 const part = sheetDamageParts[0];
+             if (parsed && sheetDamagePartList[0].valueAlt) {
+                 const part = sheetDamagePartList[0];
                  if (part.valueAlt) {
                      if (parsed.die === null) {
                         part.valueAlt.flatMultiplier = parsed.count;
@@ -971,17 +989,17 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
             });
         }
 
-        if (!calculatedHalvedDamage && sheetDamageParts.length > 0 && sheetDamageParts[0].valueAlt) {
-            const part = sheetDamageParts[0];
+        if (!calculatedHalvedDamage && sheetDamagePartList.length > 0 && sheetDamagePartList[0].valueAlt) {
+            const part = sheetDamagePartList[0];
             const altFormula = part.valueAlt.custom?.enabled ? part.valueAlt.custom.formula : (part.valueAlt.dice ? `${part.valueAlt.flatMultiplier||1}${part.valueAlt.dice}${part.valueAlt.bonus?(part.valueAlt.bonus>0?'+'+part.valueAlt.bonus:part.valueAlt.bonus):''}` : `${part.valueAlt.flatMultiplier}`);
             calculatedHalvedDamage = altFormula;
         }
 
         // Apply Manual Overrides again to be safe
-        if (overrides.damageFormula && sheetDamageParts.length > 0) {
+        if (overrides.damageFormula && sheetDamagePartList.length > 0) {
             const parsed = parseDamageString(overrides.damageFormula);
-            if (parsed && sheetDamageParts[0].value) {
-                 const part = sheetDamageParts[0];
+            if (parsed && sheetDamagePartList[0].value) {
+                 const part = sheetDamagePartList[0];
                  if (parsed.die === null) {
                     part.value.flatMultiplier = parsed.count;
                     part.value.dice = "";
@@ -999,10 +1017,10 @@ export async function updateSingleActor(actor, newTier, overrides = {}) {
             }
         }
 
-        if (overrides.halvedDamageFormula && sheetDamageParts.length > 0) {
+        if (overrides.halvedDamageFormula && sheetDamagePartList.length > 0) {
             const parsed = parseDamageString(overrides.halvedDamageFormula);
-            if (parsed && sheetDamageParts[0].valueAlt) {
-                 const part = sheetDamageParts[0];
+            if (parsed && sheetDamagePartList[0].valueAlt) {
+                 const part = sheetDamagePartList[0];
                  if (parsed.die === null) {
                     part.valueAlt.flatMultiplier = parsed.count;
                     part.valueAlt.dice = "";

--- a/scripts/dice-probability.js
+++ b/scripts/dice-probability.js
@@ -1,5 +1,6 @@
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 import { SKULL_IMAGE_PATH } from "./module.js";
+import { localize } from "./i18n.js";
 
 export class DiceProbability extends HandlebarsApplicationMixin(ApplicationV2) {
 
@@ -70,7 +71,7 @@ export class DiceProbability extends HandlebarsApplicationMixin(ApplicationV2) {
         id: "daggerheart-dice-prob",
         tag: "form",
         window: {
-            title: "Dice Probability Calculator",
+            title: "DHAM.Windows.DiceProbability",
             icon: "fas fa-dice-d20",
             resizable: false,
             width: 460,
@@ -146,7 +147,7 @@ export class DiceProbability extends HandlebarsApplicationMixin(ApplicationV2) {
                 ...stats,
                 diceNotation,
                 difficulty: this.formData.difficulty,
-                rollTypeLabel: this.formData.rollType === 1 ? "Advantage" : (this.formData.rollType === -1 ? "Disadvantage" : "Normal")
+                rollTypeLabel: this.formData.rollType === 1 ? localize("DiceProbability.Advantage") : (this.formData.rollType === -1 ? localize("DiceProbability.Disadvantage") : localize("DiceProbability.Normal"))
             };
         } else {
             // --- D20 Calculation ---
@@ -163,15 +164,15 @@ export class DiceProbability extends HandlebarsApplicationMixin(ApplicationV2) {
                 ...stats,
                 diceNotation,
                 difficulty: this.d20Data.difficulty,
-                rollTypeLabel: this.d20Data.rollType === 1 ? "Advantage" : (this.d20Data.rollType === -1 ? "Disadvantage" : "Normal"),
+                rollTypeLabel: this.d20Data.rollType === 1 ? localize("DiceProbability.Advantage") : (this.d20Data.rollType === -1 ? localize("DiceProbability.Disadvantage") : localize("DiceProbability.Normal")),
                 criticalThreshold: this.d20Data.criticalThreshold
             };
         }
 
         // Determine dynamic label for the modifier die row (Duality mode only)
-        let advLabel = "Adv. Die";
+        let advLabel = localize("DiceProbability.AdvDie");
         if (this.formData.rollType === -1) {
-            advLabel = "Dis. Die";
+            advLabel = localize("DiceProbability.DisDie");
         }
 
         // Current data based on mode
@@ -264,7 +265,7 @@ export class DiceProbability extends HandlebarsApplicationMixin(ApplicationV2) {
 
     async _onSendToChat(event, target) {
         let stats, diceNotation, content;
-        const MESSAGE_TITLE = "Probability Analysis";
+        const MESSAGE_TITLE = localize("DiceProbability.ProbabilityAnalysis");
         const BACKGROUND_IMAGE = SKULL_IMAGE_PATH;
         const MIN_HEIGHT = "150px";
 
@@ -283,12 +284,12 @@ export class DiceProbability extends HandlebarsApplicationMixin(ApplicationV2) {
             const { success, fail, crit } = stats;
             const commandContent = `
                 <div style="text-align: left; padding: 5px;">
-                    <p><strong>Dice:</strong> ${diceNotation}</p>
-                    <p><strong>Difficulty:</strong> ${this.formData.difficulty}</p>
+                    <p><strong>${localize("DiceProbability.Dice")}:</strong> ${diceNotation}</p>
+                    <p><strong>${localize("Common.Difficulty")}:</strong> ${this.formData.difficulty}</p>
                     <hr style="border-color: #C9A060; opacity: 0.5;">
-                    <p style="color: #98fb98;"><strong>Success:</strong> ${success}%</p>
-                    <p style="color: #ff6b6b;"><strong>Failure:</strong> ${fail}%</p>
-                    <p style="color: #ea80fc;"><strong>Critical (Doubles):</strong> ${crit}%</p>
+                    <p style="color: #98fb98;"><strong>${localize("Common.Success")}:</strong> ${success}%</p>
+                    <p style="color: #ff6b6b;"><strong>${localize("Common.Failure")}:</strong> ${fail}%</p>
+                    <p style="color: #ea80fc;"><strong>${localize("DiceProbability.CriticalDoubles")}:</strong> ${crit}%</p>
                 </div>
             `;
 
@@ -318,18 +319,18 @@ export class DiceProbability extends HandlebarsApplicationMixin(ApplicationV2) {
 
             diceNotation = this._buildDiceNotation();
 
-            const rollTypeLabel = this.d20Data.rollType === 1 ? "Advantage" : (this.d20Data.rollType === -1 ? "Disadvantage" : "Normal");
+            const rollTypeLabel = this.d20Data.rollType === 1 ? localize("DiceProbability.Advantage") : (this.d20Data.rollType === -1 ? localize("DiceProbability.Disadvantage") : localize("DiceProbability.Normal"));
             const { success, fail, crit } = stats;
 
             const commandContent = `
                 <div style="text-align: left; padding: 5px;">
-                    <p><strong>Dice:</strong> ${diceNotation} (${rollTypeLabel})</p>
-                    <p><strong>Difficulty:</strong> ${this.d20Data.difficulty}</p>
-                    <p><strong>Critical Threshold:</strong> ${this.d20Data.criticalThreshold}+</p>
+                    <p><strong>${localize("DiceProbability.Dice")}:</strong> ${diceNotation} (${rollTypeLabel})</p>
+                    <p><strong>${localize("Common.Difficulty")}:</strong> ${this.d20Data.difficulty}</p>
+                    <p><strong>${localize("Common.CriticalThreshold")}:</strong> ${this.d20Data.criticalThreshold}+</p>
                     <hr style="border-color: #C9A060; opacity: 0.5;">
-                    <p style="color: #98fb98;"><strong>Success:</strong> ${success}%</p>
-                    <p style="color: #ff6b6b;"><strong>Failure:</strong> ${fail}%</p>
-                    <p style="color: #ea80fc;"><strong>Critical (${this.d20Data.criticalThreshold}+):</strong> ${crit}%</p>
+                    <p style="color: #98fb98;"><strong>${localize("Common.Success")}:</strong> ${success}%</p>
+                    <p style="color: #ff6b6b;"><strong>${localize("Common.Failure")}:</strong> ${fail}%</p>
+                    <p style="color: #ea80fc;"><strong>${localize("Common.Critical")} (${this.d20Data.criticalThreshold}+):</strong> ${crit}%</p>
                 </div>
             `;
 

--- a/scripts/encounter-builder.js
+++ b/scripts/encounter-builder.js
@@ -1,6 +1,7 @@
 import { MODULE_ID, SETTING_EXTRA_COMPENDIUMS, SETTING_ENCOUNTER_FOLDER, SETTING_LAST_SOURCE } from "./module.js";
 import { POWERFUL_FEATURES } from "./rules.js";
 import { LiveManager } from "./live-manager.js"; 
+import { prepareDocumentCreateData } from "./foundry-compat.js";
 
 // Import DialogV2 to fix deprecation warning
 const { ApplicationV2, HandlebarsApplicationMixin, DialogV2 } = foundry.applications.api;
@@ -619,10 +620,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
 
                 let createdActor;
                 if (originalActor.compendium) {
-                    // Method 1: Robust Copy via toObject (Works reliably in V13)
-                    const data = originalActor.toObject();
-                    delete data._id; // Ensure new ID
-                    data.folder = subFolder.id;
+                    const data = prepareDocumentCreateData(originalActor, game.actors, { folder: subFolder.id });
                     createdActor = await Actor.create(data);
                 } else {
                     // Method 2: Clone for World Actors
@@ -646,7 +644,8 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
                         if (entry) {
                             const itemDoc = await featurePack.getDocument(entry._id);
                             if (itemDoc) {
-                                await createdActor.createEmbeddedDocuments("Item", [itemDoc.toObject()]);
+                                const itemData = prepareDocumentCreateData(itemDoc, game.items);
+                                await createdActor.createEmbeddedDocuments("Item", [itemData]);
                             }
                         }
                     }

--- a/scripts/encounter-builder.js
+++ b/scripts/encounter-builder.js
@@ -2,6 +2,7 @@ import { MODULE_ID, SETTING_EXTRA_COMPENDIUMS, SETTING_ENCOUNTER_FOLDER, SETTING
 import { POWERFUL_FEATURES } from "./rules.js";
 import { LiveManager } from "./live-manager.js"; 
 import { prepareDocumentCreateData } from "./foundry-compat.js";
+import { localize, localizeType } from "./i18n.js";
 
 // Import DialogV2 to fix deprecation warning
 const { ApplicationV2, HandlebarsApplicationMixin, DialogV2 } = foundry.applications.api;
@@ -53,7 +54,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
         id: "daggerheart-encounter-builder",
         tag: "form",
         window: {
-            title: "Encounter Builder",
+            title: "DHAM.Windows.EncounterBuilder",
             icon: "fas fa-dungeon",
             resizable: true,
             width: 1100,
@@ -124,9 +125,9 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
         // --- Source Options ---
         const extraPacks = game.settings.get(MODULE_ID, SETTING_EXTRA_COMPENDIUMS) || [];
         const sourceOptions = [
-            { value: "all", label: "All Sources", selected: this.filterSource === "all" },
-            { value: "world", label: "World (Actors)", selected: this.filterSource === "world" },
-            { value: "daggerheart.adversaries", label: "System Compendium", selected: this.filterSource === "daggerheart.adversaries" }
+            { value: "all", label: localize("Common.AllSources"), selected: this.filterSource === "all" },
+            { value: "world", label: localize("Common.WorldActors"), selected: this.filterSource === "world" },
+            { value: "daggerheart.adversaries", label: localize("Common.SystemCompendium"), selected: this.filterSource === "daggerheart.adversaries" }
         ];
 
         extraPacks.forEach(packId => {
@@ -187,18 +188,18 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
         const typeSet = new Set(adversaries.map(a => a.type).filter(t => t));
         const typeOptions = Array.from(typeSet).sort().map(t => ({
             value: t,
-            label: t.charAt(0).toUpperCase() + t.slice(1),
+            label: localizeType(t),
             selected: this.filterType === t
         }));
-        typeOptions.unshift({ value: "all", label: "All Types", selected: this.filterType === "all" });
+        typeOptions.unshift({ value: "all", label: localize("Common.AllTypes"), selected: this.filterType === "all" });
 
         // --- Fear Options ---
         const fearOptions = [
-            { value: "0-1", label: "Low (0–1 Fear)", selected: this.fearBudget === "0-1" },
-            { value: "1-3", label: "Moderate (1–3 Fear)", selected: this.fearBudget === "1-3" },
-            { value: "2-4", label: "High (2–4 Fear)", selected: this.fearBudget === "2-4" },
-            { value: "4-8", label: "Extreme (4–8 Fear)", selected: this.fearBudget === "4-8" },
-            { value: "6-12", label: "Insane (6–12 Fear)", selected: this.fearBudget === "6-12" }
+            { value: "0-1", label: localize("Encounter.Fear.Low"), selected: this.fearBudget === "0-1" },
+            { value: "1-3", label: localize("Encounter.Fear.Moderate"), selected: this.fearBudget === "1-3" },
+            { value: "2-4", label: localize("Encounter.Fear.High"), selected: this.fearBudget === "2-4" },
+            { value: "4-8", label: localize("Encounter.Fear.Extreme"), selected: this.fearBudget === "4-8" },
+            { value: "6-12", label: localize("Encounter.Fear.Insane"), selected: this.fearBudget === "6-12" }
         ];
 
         // --- PC Count Options ---
@@ -217,7 +218,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             
             return {
                 ...unit,
-                damageBoostTooltip: `Add +${die} Damage (Lowers Budget Limit)`
+                damageBoostTooltip: localize("EncounterBuilder.DamageBoost", { die })
             };
         });
 
@@ -245,14 +246,14 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
 
         // --- Determine Skull Image ---
         let skullImg = "";
-        switch (bpData.difficultyLabel) {
-            case "Very Easy": skullImg = "modules/daggerheart-advmanager/assets/images/skull-very-easy.webp"; break;
-            case "Easy": skullImg = "modules/daggerheart-advmanager/assets/images/skull-easy.webp"; break;
-            case "Balanced": skullImg = "modules/daggerheart-advmanager/assets/images/skull-balanced.webp"; break;
-            case "Challenging": skullImg = "modules/daggerheart-advmanager/assets/images/skull-challenging.webp"; break;
-            case "Hard": skullImg = "modules/daggerheart-advmanager/assets/images/skull-hard.webp"; break;
-            case "Deadly": skullImg = "modules/daggerheart-advmanager/assets/images/skull-deadly.webp"; break;
-            case "Out of Tier": skullImg = "modules/daggerheart-advmanager/assets/images/skull-deadly.webp"; break;
+        switch (bpData.difficultyKey) {
+            case "veryEasy": skullImg = "modules/daggerheart-advmanager/assets/images/skull-very-easy.webp"; break;
+            case "easy": skullImg = "modules/daggerheart-advmanager/assets/images/skull-easy.webp"; break;
+            case "balanced": skullImg = "modules/daggerheart-advmanager/assets/images/skull-balanced.webp"; break;
+            case "challenging": skullImg = "modules/daggerheart-advmanager/assets/images/skull-challenging.webp"; break;
+            case "hard": skullImg = "modules/daggerheart-advmanager/assets/images/skull-hard.webp"; break;
+            case "deadly": skullImg = "modules/daggerheart-advmanager/assets/images/skull-deadly.webp"; break;
+            case "outOfTier": skullImg = "modules/daggerheart-advmanager/assets/images/skull-deadly.webp"; break;
             default: skullImg = "modules/daggerheart-advmanager/assets/images/skull-balanced.webp";
         }
 
@@ -275,7 +276,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             // BP Data
             pcCount: this.pcCount,
             pcTier: this.pcTier,
-            pcTierOptions: [1, 2, 3, 4].map(t => ({ value: t, label: `Tier ${t}`, selected: t === this.pcTier })),
+            pcTierOptions: [1, 2, 3, 4].map(t => ({ value: t, label: localize("Common.Tier", { tier: t }), selected: t === this.pcTier })),
             bpData: bpData,
             manualModifiers: this.manualModifiers,
             
@@ -287,7 +288,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
 
             // Folder Mode State (NEW)
             useAutoFolder: this.useAutoFolder,
-            autoFolderTooltip: this.useAutoFolder ? "Mode: Auto-Generate Folder Name" : "Mode: Manual Folder Name"
+            autoFolderTooltip: this.useAutoFolder ? localize("EncounterBuilder.AutoFolder") : localize("EncounterBuilder.ManualFolder")
         };
     }
 
@@ -359,44 +360,44 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
 
         if (this.manualModifiers.easier) {
             limit -= 1;
-            modifiers.push({ label: "Easier/Shorter", val: "-1", active: true, manual: true, key: 'easier' });
+            modifiers.push({ label: localize("Encounter.Modifiers.EasierShorter"), val: "-1", active: true, manual: true, key: 'easier' });
         } else {
-            modifiers.push({ label: "Easier/Shorter", val: "-1", active: false, manual: true, key: 'easier' });
+            modifiers.push({ label: localize("Encounter.Modifiers.EasierShorter"), val: "-1", active: false, manual: true, key: 'easier' });
         }
 
         if (soloCount >= 2) {
             limit -= 2;
-            modifiers.push({ label: "2+ Solos", val: "-2", active: true, manual: false });
+            modifiers.push({ label: localize("Encounter.Modifiers.TwoPlusSolos"), val: "-2", active: true, manual: false });
         } else {
-            modifiers.push({ label: "2+ Solos", val: "-2", active: false, manual: false, disabled: true });
+            modifiers.push({ label: localize("Encounter.Modifiers.TwoPlusSolos"), val: "-2", active: false, manual: false, disabled: true });
         }
 
         if (hasDamageBoost) {
             limit -= 2;
-            modifiers.push({ label: "Damage Boost", val: "-2", active: true, manual: false });
+            modifiers.push({ label: localize("Encounter.Modifiers.DamageBoost"), val: "-2", active: true, manual: false });
         } else {
-            modifiers.push({ label: "Damage Boost", val: "-2", active: false, manual: false, disabled: true });
+            modifiers.push({ label: localize("Encounter.Modifiers.DamageBoost"), val: "-2", active: false, manual: false, disabled: true });
         }
 
         if (hasLowerTier) {
             limit += 1;
-            modifiers.push({ label: "Lower Tier Used", val: "+1", active: true, manual: false });
+            modifiers.push({ label: localize("Encounter.Modifiers.LowerTierUsed"), val: "+1", active: true, manual: false });
         } else {
-            modifiers.push({ label: "Lower Tier Used", val: "+1", active: false, manual: false, disabled: true });
+            modifiers.push({ label: localize("Encounter.Modifiers.LowerTierUsed"), val: "+1", active: false, manual: false, disabled: true });
         }
 
         if (this.encounterList.length > 0 && !hasSpecialType) {
             limit += 1;
-            modifiers.push({ label: "No Major Adversaries", val: "+1", active: true, manual: false });
+            modifiers.push({ label: localize("Encounter.Modifiers.NoMajorAdversaries"), val: "+1", active: true, manual: false });
         } else {
-            modifiers.push({ label: "No Major Adversaries", val: "+1", active: false, manual: false, disabled: true });
+            modifiers.push({ label: localize("Encounter.Modifiers.NoMajorAdversaries"), val: "+1", active: false, manual: false, disabled: true });
         }
 
         if (this.manualModifiers.harder) {
             limit += 2;
-            modifiers.push({ label: "Harder/Longer", val: "+2", active: true, manual: true, key: 'harder' });
+            modifiers.push({ label: localize("Encounter.Modifiers.HarderLonger"), val: "+2", active: true, manual: true, key: 'harder' });
         } else {
-            modifiers.push({ label: "Harder/Longer", val: "+2", active: false, manual: true, key: 'harder' });
+            modifiers.push({ label: localize("Encounter.Modifiers.HarderLonger"), val: "+2", active: false, manual: true, key: 'harder' });
         }
 
         const diff = currentCost - limit;
@@ -429,20 +430,20 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
 
         level = Math.max(0, Math.min(5, level + shift));
 
-        let difficultyLabel = "Balanced";
+        let difficultyKey = "balanced";
         let difficultyClass = "diff-balanced";
 
         switch (level) {
-            case 0: difficultyLabel = "Very Easy"; difficultyClass = "diff-very-easy"; break;
-            case 1: difficultyLabel = "Easy"; difficultyClass = "diff-easy"; break;
-            case 2: difficultyLabel = "Balanced"; difficultyClass = "diff-balanced"; break;
-            case 3: difficultyLabel = "Challenging"; difficultyClass = "diff-challenging"; break;
-            case 4: difficultyLabel = "Hard"; difficultyClass = "diff-deadly"; break;
-            case 5: difficultyLabel = "Deadly"; difficultyClass = "diff-deadly"; break;
+            case 0: difficultyKey = "veryEasy"; difficultyClass = "diff-very-easy"; break;
+            case 1: difficultyKey = "easy"; difficultyClass = "diff-easy"; break;
+            case 2: difficultyKey = "balanced"; difficultyClass = "diff-balanced"; break;
+            case 3: difficultyKey = "challenging"; difficultyClass = "diff-challenging"; break;
+            case 4: difficultyKey = "hard"; difficultyClass = "diff-deadly"; break;
+            case 5: difficultyKey = "deadly"; difficultyClass = "diff-deadly"; break;
         }
 
         if (outOfTier) {
-            difficultyLabel = "Out of Tier";
+            difficultyKey = "outOfTier";
             difficultyClass = "diff-deadly";
         }
 
@@ -455,9 +456,23 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             remaining: limit - currentCost,
             modifiers: modifiers,
             statusColor: statusColor,
-            difficultyLabel: difficultyLabel,
+            difficultyKey: difficultyKey,
+            difficultyLabel: this._localizeDifficulty(difficultyKey),
             difficultyClass: difficultyClass
         };
+    }
+
+    _localizeDifficulty(key) {
+        const keys = {
+            veryEasy: "Encounter.Difficulty.VeryEasy",
+            easy: "Encounter.Difficulty.Easy",
+            balanced: "Encounter.Difficulty.Balanced",
+            challenging: "Encounter.Difficulty.Challenging",
+            hard: "Encounter.Difficulty.Hard",
+            deadly: "Encounter.Difficulty.Deadly",
+            outOfTier: "Encounter.Difficulty.OutOfTier"
+        };
+        return localize(keys[key] || keys.balanced);
     }
 
     // ... (rest of the file remains unchanged)
@@ -513,6 +528,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             name: actor.name,
             tier: Number(actor.system.tier) || 1,
             type: (actor.system.type || "standard").toLowerCase(),
+            typeLabel: localizeType(actor.system.type || "standard"),
             img: this._resolveImage(actor.img),
             isCompendium: false,
             packId: null,
@@ -527,6 +543,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             name: indexEntry.name,
             tier: Number(indexEntry.system?.tier) || 1,
             type: (indexEntry.system?.type || "standard").toLowerCase(),
+            typeLabel: localizeType(indexEntry.system?.type || "standard"),
             img: this._resolveImage(indexEntry.img),
             isCompendium: true,
             packId: packId,
@@ -540,7 +557,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
      */
     async _executeCreateEncounter(customName = null) {
         if (this.encounterList.length === 0) {
-            ui.notifications.warn("No adversaries in the encounter to create.");
+            ui.notifications.warn(localize("EncounterBuilder.NoAdversariesToCreate"));
             return [];
         }
 
@@ -551,7 +568,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             featureIndex = await featurePack.getIndex();
         }
 
-        const rootName = game.settings.get(MODULE_ID, SETTING_ENCOUNTER_FOLDER) || "💀 My Encounters";
+        const rootName = game.settings.get(MODULE_ID, SETTING_ENCOUNTER_FOLDER) || localize("Defaults.MyEncounters");
         
         // Ensure Root Folder Exists
         let rootFolder = game.folders.find(f => f.name === rootName && f.type === "Actor");
@@ -672,20 +689,20 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
         
         try {
             const result = await DialogV2.prompt({
-                window: { title: "Encounter Name" },
+                window: { title: localize("Windows.EncounterName") },
                 content: `
                     <div style="margin-bottom: 10px;">
-                        <label style="display: block; font-weight: bold; margin-bottom: 5px;" for="${inputId}">Folder Name:</label>
-                        <input type="text" id="${inputId}" placeholder="e.g., Boss Fight Room 3" autofocus required 
+                        <label style="display: block; font-weight: bold; margin-bottom: 5px;" for="${inputId}">${localize("EncounterBuilder.FolderName")}</label>
+                        <input type="text" id="${inputId}" placeholder="${localize("EncounterBuilder.FolderPlaceholder")}" autofocus required
                                style="width: 100%; box-sizing: border-box; padding: 5px; background: #222; color: #fff; border: 1px solid #777;"/>
                     </div>
                 `,
                 ok: {
-                    label: "Create",
+                    label: localize("EncounterBuilder.Create"),
                     icon: "fas fa-check",
                     callback: (event, button, dialog) => {
                         const input = document.getElementById(inputId);
-                        return input ? input.value : "Untitled Encounter";
+                        return input ? input.value : localize("EncounterBuilder.UntitledEncounter");
                     }
                 },
                 rejectClose: false
@@ -711,11 +728,11 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             const result = await this._executeCreateEncounter(folderName);
             if (result && result.actors && result.actors.length > 0) {
                 this.lastCreatedActors = result.actors;
-                ui.notifications.info(`Encounter created in: "${result.folderName}". Check the Actor directory.`);
+                ui.notifications.info(localize("EncounterBuilder.EncounterCreated", { folder: result.folderName }));
             }
         } catch (err) {
             console.error(err);
-            ui.notifications.error("Failed to create encounter. Check console.");
+            ui.notifications.error(localize("EncounterBuilder.FailedCreate"));
         }
     }
 
@@ -737,7 +754,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             
             const scene = canvas.scene;
             if (!scene) {
-                ui.notifications.warn("No active scene to place tokens.");
+                ui.notifications.warn(localize("EncounterBuilder.NoActiveScene"));
                 return;
             }
 
@@ -767,11 +784,11 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             }
 
             await scene.createEmbeddedDocuments("Token", tokensData);
-            ui.notifications.info(`Encounter created and ${created.length} tokens placed on scene (Hidden).`);
+            ui.notifications.info(localize("EncounterBuilder.EncounterPlaced", { count: created.length }));
             
         } catch (err) {
             console.error(err);
-            ui.notifications.error("Failed to place encounter. Check console.");
+            ui.notifications.error(localize("EncounterBuilder.FailedPlace"));
         }
     }
 
@@ -1037,6 +1054,7 @@ export class EncounterBuilder extends HandlebarsApplicationMixin(ApplicationV2) 
             name: actor.name,
             tier: Number(actor.system.tier) || 1,
             type: (actor.system.type || "standard").toLowerCase(),
+            typeLabel: localizeType(actor.system.type || "standard"),
             img: this._resolveImage(actor.img),
             isCompendium: false,
             packId: null,

--- a/scripts/feature-updater.js
+++ b/scripts/feature-updater.js
@@ -1,4 +1,5 @@
 import { ADVERSARY_BENCHMARKS } from "./rules.js";
+import { localize, localizeType } from "./i18n.js";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -24,7 +25,7 @@ export class FeatureUpdater extends HandlebarsApplicationMixin(ApplicationV2) {
         id: "daggerheart-feature-updater",
         tag: "form",
         window: {
-            title: "Feature Flag Updater",
+            title: "DHAM.Windows.FeatureUpdater",
             icon: "fas fa-tags",
             resizable: false,
             width: 400,
@@ -47,7 +48,7 @@ export class FeatureUpdater extends HandlebarsApplicationMixin(ApplicationV2) {
         // Prepare Tier Options
         const tiers = [1, 2, 3, 4].map(t => ({
             value: t,
-            label: `Tier ${t}`,
+            label: localize("Common.Tier", { tier: t }),
             selected: t === this.formState.tier
         }));
 
@@ -59,7 +60,7 @@ export class FeatureUpdater extends HandlebarsApplicationMixin(ApplicationV2) {
             const isSelected = capitalizedKey.toLowerCase() === (this.formState.type || "").toLowerCase();
             return {
                 value: capitalizedKey, 
-                label: capitalizedKey,
+                label: localizeType(k),
                 selected: isSelected
             };
         });
@@ -104,13 +105,13 @@ export class FeatureUpdater extends HandlebarsApplicationMixin(ApplicationV2) {
             const data = JSON.parse(event.dataTransfer.getData("text/plain"));
             
             if (data.type !== "Item") {
-                ui.notifications.warn("Please drop an Item.");
+                ui.notifications.warn(localize("FeatureUpdater.PleaseDropItem"));
                 return;
             }
 
             const item = await fromUuid(data.uuid);
             if (!item) {
-                ui.notifications.error("Could not resolve Item UUID.");
+                ui.notifications.error(localize("FeatureUpdater.CouldNotResolveItem"));
                 return;
             }
 
@@ -130,19 +131,19 @@ export class FeatureUpdater extends HandlebarsApplicationMixin(ApplicationV2) {
 
         } catch (e) {
             console.error(e);
-            ui.notifications.error("Invalid drop data.");
+            ui.notifications.error(localize("FeatureUpdater.InvalidDrop"));
         }
     }
 
     async _onSubmit(event, form, formData) {
         if (!this.selectedItemUuid) {
-            ui.notifications.warn("No item selected.");
+            ui.notifications.warn(localize("FeatureUpdater.NoItemSelected"));
             return;
         }
 
         const item = await fromUuid(this.selectedItemUuid);
         if (!item) {
-            ui.notifications.error("Item no longer exists.");
+            ui.notifications.error(localize("FeatureUpdater.CouldNotResolveItem"));
             this.selectedItem = null;
             this.selectedItemUuid = null;
             this.render();
@@ -186,7 +187,7 @@ export class FeatureUpdater extends HandlebarsApplicationMixin(ApplicationV2) {
 
         } catch (err) {
             console.error(err);
-            ui.notifications.error("Failed to update item flags.");
+            ui.notifications.error(localize("FeatureUpdater.FailedUpdate"));
         }
     }
 }

--- a/scripts/foundry-compat.js
+++ b/scripts/foundry-compat.js
@@ -1,0 +1,51 @@
+/**
+ * Small compatibility helpers for Foundry VTT v13/v14 API edges.
+ */
+
+/**
+ * Finds an open application by id across ApplicationV2 instances and legacy ui.windows.
+ * @param {string} id - Application id from DEFAULT_OPTIONS.
+ * @param {typeof foundry.applications.api.ApplicationV2|null} ApplicationClass - Optional AppV2 subclass.
+ * @returns {Application|null}
+ */
+export function findApplicationById(id, ApplicationClass = null) {
+    const seen = new Set();
+    const classes = [ApplicationClass, foundry.applications?.api?.ApplicationV2].filter(Boolean);
+
+    for (const cls of classes) {
+        if (typeof cls.instances !== "function") continue;
+        for (const app of cls.instances()) {
+            if (seen.has(app)) continue;
+            seen.add(app);
+            if (app?.id === id) return app;
+        }
+    }
+
+    return Object.values(globalThis.ui?.windows ?? {}).find(app => app?.id === id) || null;
+}
+
+/**
+ * Prepares document source data for creating a fresh world or embedded Document.
+ * Uses Foundry's fromCompendium transform where available and strips identity/stats.
+ * @param {Document|Object} document - Source document or data.
+ * @param {WorldCollection|null} collection - Matching world collection, e.g. game.actors.
+ * @param {Object} updateData - Extra creation data to merge in.
+ * @returns {Object} Safe creation data.
+ */
+export function prepareDocumentCreateData(document, collection = null, updateData = {}) {
+    let data;
+
+    if (document?.compendium && collection && typeof collection.fromCompendium === "function") {
+        data = collection.fromCompendium(document);
+    } else if (document?.toObject) {
+        data = document.toObject();
+    } else {
+        data = foundry.utils.deepClone(document ?? {});
+    }
+
+    data = foundry.utils.deepClone(data);
+    delete data._id;
+    delete data._stats;
+
+    return foundry.utils.mergeObject(data, updateData, { inplace: false });
+}

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -1,0 +1,86 @@
+export const I18N_NAMESPACE = "DHAM";
+
+const SYSTEM_KEY_ALIASES = {
+    "Common.Adversary": "DAGGERHEART.GENERAL.Adversary.singular",
+    "Common.Adversaries": "DAGGERHEART.GENERAL.Adversary.plural",
+    "Common.Critical": "DAGGERHEART.GENERAL.criticalShort",
+    "Common.CriticalThreshold": "DAGGERHEART.ACTIONS.Settings.criticalThreshold",
+    "Common.Current": "DAGGERHEART.UI.Chat.damageRoll.currentTarget",
+    "Common.Difficulty": "DAGGERHEART.GENERAL.difficulty",
+    "Common.Experiences": "DAGGERHEART.GENERAL.Experience.plural",
+    "Common.Failure": "DAGGERHEART.GENERAL.failure",
+    "Common.Feature": "TYPES.Item.feature",
+    "Common.Features": "DAGGERHEART.GENERAL.features",
+    "Common.HP": "DAGGERHEART.GENERAL.HitPoints.short",
+    "Common.Max": "DAGGERHEART.GENERAL.max",
+    "Common.None": "DAGGERHEART.GENERAL.none",
+    "Common.Preview": "DAGGERHEART.GENERAL.preview",
+    "Common.Stress": "DAGGERHEART.GENERAL.stress",
+    "Common.Success": "DAGGERHEART.GENERAL.success",
+    "Common.Type": "DAGGERHEART.GENERAL.type",
+    "CompendiumStats.HitPoints": "DAGGERHEART.GENERAL.HitPoints.plural",
+    "DamageEngine.Custom": "DAGGERHEART.GENERAL.custom",
+    "DiceProbability.Adv": "DAGGERHEART.GENERAL.Advantage.short",
+    "DiceProbability.Advantage": "DAGGERHEART.GENERAL.Advantage.full",
+    "DiceProbability.Dice": "DAGGERHEART.GENERAL.Dice.plural",
+    "DiceProbability.Dis": "DAGGERHEART.GENERAL.Disadvantage.short",
+    "DiceProbability.Disadvantage": "DAGGERHEART.GENERAL.Disadvantage.full",
+    "DiceProbability.DualityDice": "DAGGERHEART.GENERAL.dualityDice",
+    "DiceProbability.Results": "DAGGERHEART.GENERAL.result.plural",
+    "DiceProbability.Roll": "DAGGERHEART.GENERAL.roll",
+    "DiceProbability.RollType": "DAGGERHEART.APPLICATIONS.TagTeamSelect.rollType",
+    "DiceProbability.SendToChat": "DAGGERHEART.UI.Tooltip.sendToChat",
+    "Importer.Action": "DAGGERHEART.CONFIG.FeatureForm.action",
+    "Importer.Passive": "DAGGERHEART.CONFIG.FeatureForm.passive",
+    "Importer.Reaction": "DAGGERHEART.CONFIG.FeatureForm.reaction",
+    "LiveManager.MagicalDamage": "DAGGERHEART.GENERAL.Damage.magicalDamage",
+    "LiveManager.MagShort": "DAGGERHEART.CONFIG.DamageType.magical.abbreviation",
+    "LiveManager.Minion": "DAGGERHEART.CONFIG.AdversaryType.minion.label",
+    "LiveManager.NewAdversary": "DAGGERHEART.ACTORS.Environment.newAdversary",
+    "LiveManager.PhysicalDamage": "DAGGERHEART.GENERAL.Damage.physicalDamage",
+    "Types.bruiser": "DAGGERHEART.CONFIG.AdversaryType.bruiser.label",
+    "Types.horde": "DAGGERHEART.CONFIG.AdversaryType.horde.label",
+    "Types.leader": "DAGGERHEART.CONFIG.AdversaryType.leader.label",
+    "Types.minion": "DAGGERHEART.CONFIG.AdversaryType.minion.label",
+    "Types.ranged": "DAGGERHEART.CONFIG.AdversaryType.ranged.label",
+    "Types.skulk": "DAGGERHEART.CONFIG.AdversaryType.skulk.label",
+    "Types.social": "DAGGERHEART.CONFIG.AdversaryType.social.label",
+    "Types.solo": "DAGGERHEART.CONFIG.AdversaryType.solo.label",
+    "Types.standard": "DAGGERHEART.CONFIG.AdversaryType.standard.label",
+    "Types.support": "DAGGERHEART.CONFIG.AdversaryType.support.label",
+    "FeatureForms.action": "DAGGERHEART.CONFIG.FeatureForm.action",
+    "FeatureForms.passive": "DAGGERHEART.CONFIG.FeatureForm.passive",
+    "FeatureForms.reaction": "DAGGERHEART.CONFIG.FeatureForm.reaction"
+};
+
+function systemLocalize(aliasKey, data = null) {
+    const systemKey = SYSTEM_KEY_ALIASES[aliasKey];
+    if (!systemKey) return null;
+    const value = data ? game.i18n.format(systemKey, data) : game.i18n.localize(systemKey);
+    return value === systemKey ? null : value;
+}
+
+export function localize(key, data = null) {
+    const fullKey = `${I18N_NAMESPACE}.${key}`;
+    const systemValue = systemLocalize(key, data);
+    if (systemValue) return systemValue;
+
+    const value = data ? game.i18n.format(fullKey, data) : game.i18n.localize(fullKey);
+    if (value !== fullKey) return value;
+
+    return fullKey;
+}
+
+export function localizeType(type) {
+    const key = String(type || "standard").toLowerCase();
+    const label = localize(`Types.${key}`);
+    if (label !== `${I18N_NAMESPACE}.Types.${key}`) return label;
+    return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+export function localizeFeatureForm(form) {
+    const key = String(form || "").toLowerCase();
+    if (!key) return "";
+    const label = localize(`FeatureForms.${key}`);
+    return label === `${I18N_NAMESPACE}.FeatureForms.${key}` ? key.charAt(0).toUpperCase() + key.slice(1) : label;
+}

--- a/scripts/importer.js
+++ b/scripts/importer.js
@@ -3,6 +3,8 @@
  * Reads Actor compendiums, extracts embedded items, and creates organized
  * world Item documents with importedFrom flags for feature lookup.
  */
+import { localize } from "./i18n.js";
+
 
 // Items that should ALWAYS be imported, even if they exist in the folder
 const ALWAYS_DUPLICATE = [
@@ -53,14 +55,14 @@ export async function importFeatures(compendiumId, rootFolderName, customTag) {
 
     const pack = game.packs.get(compendiumId);
     if (!pack) {
-        const msg = `Compendium "${compendiumId}" not found.`;
+        const msg = localize("Importer.CompendiumNotFound", { compendium: compendiumId });
         ui.notifications.error(msg);
         console.error(msg);
         return;
     }
 
     if (pack.documentName !== "Actor") {
-        ui.notifications.error(`Compendium "${compendiumId}" is not an Actor compendium.`);
+        ui.notifications.error(localize("Importer.CompendiumNotActor", { compendium: compendiumId }));
         return;
     }
 
@@ -117,9 +119,9 @@ export async function importFeatures(compendiumId, rootFolderName, customTag) {
      */
     function getFeatureCategory(item) {
         const form = String(item.system?.featureForm || "").toLowerCase().trim();
-        if (form.includes("reaction")) return "Reaction";
-        if (form.includes("action")) return "Action";
-        return "Passive";
+        if (form.includes("reaction")) return localize("Importer.Reaction");
+        if (form.includes("action")) return localize("Importer.Action");
+        return localize("Importer.Passive");
     }
 
     /**

--- a/scripts/live-manager.js
+++ b/scripts/live-manager.js
@@ -4,6 +4,7 @@ import { MODULE_ID, SETTING_IMPORT_FOLDER, SETTING_EXTRA_COMPENDIUMS, SETTING_FE
 import { CompendiumManager } from "./compendium-manager.js";
 import { CompendiumStats } from "./compendium-stats.js";
 import { DiceProbability } from "./dice-probability.js"; 
+import { localize, localizeType, localizeFeatureForm } from "./i18n.js";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -86,7 +87,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
         id: "daggerheart-live-preview",
         tag: "form",
         window: {
-            title: "Adversary Live Manager",
+            title: "DHAM.Windows.AdversaryLiveManager",
             icon: "fas fa-eye",
             resizable: true,
             width: 1000,
@@ -291,7 +292,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 return list[Math.floor(Math.random() * list.length)];
             }
         }
-        return "New Experience"; 
+        return localize("LiveManager.NewExperience");
     }
 
     _calculateCritChance(threshold) {
@@ -305,9 +306,9 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
 
         // --- Determine Source List ---
         const sourceOptions = [
-            { value: "all", label: "All Sources", selected: this.source === "all" }, 
-            { value: "world", label: "World", selected: this.source === "world" },
-            { value: "daggerheart.adversaries", label: "System Compendium", selected: this.source === "daggerheart.adversaries" }
+            { value: "all", label: localize("Common.AllSources"), selected: this.source === "all" },
+            { value: "world", label: localize("Common.World"), selected: this.source === "world" },
+            { value: "daggerheart.adversaries", label: localize("Common.SystemCompendium"), selected: this.source === "daggerheart.adversaries" }
         ];
 
         // --- NEW: Add Template Option (New Adversary) ---
@@ -316,7 +317,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
         if (templatePack) {
             sourceOptions.push({
                 value: templatePackId,
-                label: "New Adversary",
+                label: localize("LiveManager.NewAdversary"),
                 selected: this.source === templatePackId
             });
         }
@@ -361,7 +362,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 const matchIndex = rawAdversaries.findIndex(a => a.id === this.initialActor.id);
                 const tokenData = {
                     id: this.initialActor.id,
-                    name: this.initialActor.name + (this.initialActor.isToken ? " (Token)" : ""),
+                    name: this.initialActor.name + (this.initialActor.isToken ? ` (${localize("LiveManager.TokenSuffix")})` : ""),
                     tier: Number(this.initialActor.system.tier) || 1,
                     advType: (this.initialActor.system.type || "standard").toLowerCase()
                 };
@@ -380,7 +381,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                     name: a.name, 
                     tier: Number(a.system.tier) || 1,
                     advType: (a.system.type || "standard").toLowerCase(),
-                    sourceLabel: "World"
+                    sourceLabel: localize("Common.World")
                 }));
             rawAdversaries.push(...worldAdvs);
 
@@ -395,7 +396,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                         name: i.name,
                         tier: Number(i.system?.tier) || 1,
                         advType: (i.system?.type || "standard").toLowerCase(),
-                        sourceLabel: "System"
+                        sourceLabel: localize("Common.SystemCompendium")
                     }));
                 rawAdversaries.push(...sysAdvs);
             }
@@ -485,7 +486,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 const typeKey = (actor.system.type || "standard").toLowerCase();
                 isMinion = typeKey === "minion";
                 isHorde = typeKey === "horde"; 
-                actorTypeLabel = typeKey.charAt(0).toUpperCase() + typeKey.slice(1); 
+                actorTypeLabel = localizeType(typeKey);
                 
                 const rawImg = actor.img;
                 const defaultIcons = [
@@ -503,7 +504,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                     isLinked: isLinked,
                     icon: isLinked ? "fa-link" : "fa-unlink",
                     cssClass: isLinked ? "status-linked" : "status-unlinked",
-                    label: isLinked ? "Linked" : "Unlinked"
+                    label: isLinked ? localize("Common.Linked") : localize("Common.Unlinked")
                 };
                 if (actor.compendium || actor.pack) linkData = null;
 
@@ -556,10 +557,10 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 }
                 
                 if (damageOptions.length > 0) {
-                    damageTooltip = "Suggested:<br>" + damageOptions.map(o => `• ${o.label}`).join("<br>");
+                    damageTooltip = localize("Common.Suggested") + "<br>" + damageOptions.map(o => `• ${o.label}`).join("<br>");
                 }
                 if (halvedDamageOptions.length > 0) {
-                    halvedDamageTooltip = "Suggested:<br>" + halvedDamageOptions.map(o => `• ${o.label}`).join("<br>");
+                    halvedDamageTooltip = localize("Common.Suggested") + "<br>" + halvedDamageOptions.map(o => `• ${o.label}`).join("<br>");
                 }
 
                 const currentCritical = currentStats.critical;
@@ -580,8 +581,8 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 const previewDirect = this.overrides.directDamage !== undefined ? (this.overrides.directDamage === "true") : currentDirect;
                 
                 directOptions = [
-                    { value: "true", label: "Yes", selected: previewDirect === true },
-                    { value: "false", label: "No", selected: previewDirect === false }
+                    { value: "true", label: localize("Common.Yes"), selected: previewDirect === true },
+                    { value: "false", label: localize("Common.No"), selected: previewDirect === false }
                 ];
 
                 previewStats = {
@@ -598,7 +599,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                     thresholdsDisplay: simResult.stats.thresholds,
                     attackModDisplay: simResult.stats.attackMod,
                     experiences: simResult.stats.previewExperiences || [],
-                    expTooltip: `Suggested:<br>Amount: ${simResult.stats.expAmountRange || "?"}<br>Modifier: ${simResult.stats.expModRange || "?"}`,
+                    expTooltip: localize("LiveManager.SuggestedAmountModifier", { amount: simResult.stats.expAmountRange || "?", modifier: simResult.stats.expModRange || "?" }),
                     damage: simResult.stats.damage,
                     damageStats: simResult.stats.damageStats, 
                     mainDamageFormula: simResult.stats.mainDamageRaw,
@@ -613,8 +614,8 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 };
 
                 if (isMinion) {
-                    previewStats.thresholdsDisplay = "None"; 
-                    previewStats.hpDisplay = "(Fixed)"; 
+                    previewStats.thresholdsDisplay = localize("Common.None");
+                    previewStats.hpDisplay = `(${localize("LiveManager.Fixed")})`;
                 }
                 
                 featurePreviewData = await Promise.all(simResult.structuredFeatures.map(async f => {
@@ -654,7 +655,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                              selected: d.value === currentVal
                          }));
                          if (featureOptions.length > 0) {
-                             optionsTooltip = "Suggested:<br>" + featureOptions.map(o => `• ${o.label}`).join("<br>");
+                             optionsTooltip = localize("Common.Suggested") + "<br>" + featureOptions.map(o => `• ${o.label}`).join("<br>");
                          }
                          damageStats = this._calculateDamageStats(currentVal);
                     }
@@ -707,14 +708,14 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                                        (this.overrides.suggestedFeaturesType === k);
                     suggestedFeaturesTypeOptions.push({
                         value: k,
-                        label: k.charAt(0).toUpperCase() + k.slice(1),
+                        label: localizeType(k),
                         selected: isSelected
                     });
                 });
 
                 suggestedFeaturesTierOptions = [1, 2, 3, 4].map(t => ({
                     value: t,
-                    label: `Tier ${t}`,
+                    label: localize("Common.Tier", { tier: t }),
                     selected: t === suggestionTier
                 }));
 
@@ -724,9 +725,9 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                     let actionClass = "";
                     if (type) {
                         const t = type.toLowerCase();
-                        if (t === "action") { actionTag = "Action"; actionClass = "tag-action"; }
-                        else if (t === "reaction") { actionTag = "Reaction"; actionClass = "tag-reaction"; }
-                        else if (t === "passive") { actionTag = "Passive"; actionClass = "tag-passive"; }
+                        if (t === "action") { actionTag = localizeFeatureForm(t); actionClass = "tag-action"; }
+                        else if (t === "reaction") { actionTag = localizeFeatureForm(t); actionClass = "tag-reaction"; }
+                        else if (t === "passive") { actionTag = localizeFeatureForm(t); actionClass = "tag-passive"; }
                     }
 
                     const imported = flags?.importedFrom || {};
@@ -738,7 +739,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                     if (customTag && customTag.trim() !== "") {
                          sourceLabel = customTag; 
                     } else if (isHomebrew) {
-                         sourceLabel = "Homebrew";
+                         sourceLabel = localize("Common.Homebrew");
                     }
                     
                     return {
@@ -863,25 +864,25 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
 
         const tiers = [1, 2, 3, 4].map(t => ({
             value: t,
-            label: `Tier ${t}`,
+            label: localize("Common.Tier", { tier: t }),
             isCurrent: t === this.targetTier,
             cssClass: t === this.targetTier ? "active" : ""
         }));
 
         const filterOptions = [
-            { value: "all", label: "All Tiers", selected: this.filterTier === "all" },
-            { value: "1", label: "Tier 1", selected: this.filterTier === "1" },
-            { value: "2", label: "Tier 2", selected: this.filterTier === "2" },
-            { value: "3", label: "Tier 3", selected: this.filterTier === "3" },
-            { value: "4", label: "Tier 4", selected: this.filterTier === "4" }
+            { value: "all", label: localize("Common.AllTiers"), selected: this.filterTier === "all" },
+            { value: "1", label: localize("Common.Tier", { tier: 1 }), selected: this.filterTier === "1" },
+            { value: "2", label: localize("Common.Tier", { tier: 2 }), selected: this.filterTier === "2" },
+            { value: "3", label: localize("Common.Tier", { tier: 3 }), selected: this.filterTier === "3" },
+            { value: "4", label: localize("Common.Tier", { tier: 4 }), selected: this.filterTier === "4" }
         ];
 
         const typeKeys = Object.keys(ADVERSARY_BENCHMARKS).sort();
         const typeOptions = [
-            { value: "all", label: "All Types", selected: this.filterType === "all" },
+            { value: "all", label: localize("Common.AllTypes"), selected: this.filterType === "all" },
             ...typeKeys.map(k => ({ 
                 value: k, 
-                label: k.charAt(0).toUpperCase() + k.slice(1), 
+                label: localizeType(k),
                 selected: this.filterType === k 
             }))
         ];
@@ -917,7 +918,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
             halvedDamageOptions,
             damageTooltip,
             halvedDamageTooltip,
-            actorName: actor?.name || "None",
+            actorName: actor?.name || localize("Common.None"),
             portraitImg: portraitImg,
             isHorde: isHorde,
             actorTypeLabel: actorTypeLabel,
@@ -1073,7 +1074,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
 
         try {
             if (actor.compendium || actor.pack) {
-                const folderName = game.settings.get(MODULE_ID, SETTING_IMPORT_FOLDER) || "Imported Adversaries";
+                const folderName = game.settings.get(MODULE_ID, SETTING_IMPORT_FOLDER) || localize("Defaults.ImportedAdversaries");
                 let folder = game.folders.find(f => f.name === folderName && f.type === "Actor");
                 if (!folder) {
                     folder = await Folder.create({ name: folderName, type: "Actor", color: "#430047" });
@@ -1136,7 +1137,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
             }
 
             if (!result && !hasManualUpdates) {
-                ui.notifications.warn("No changes were necessary.");
+                ui.notifications.warn(localize("LiveManager.NoChangesNecessary"));
             }
 
             this.filterTier = String(this.targetTier); 
@@ -1164,7 +1165,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
 
         } catch (e) {
             console.error(e);
-            ui.notifications.error("Error applying changes. Check console.");
+            ui.notifications.error(localize("LiveManager.ErrorApplying"));
         }
     }
 
@@ -1269,7 +1270,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
         if (item && item.sheet) {
             item.sheet.render(true);
         } else {
-            ui.notifications.warn("Item not found or has no sheet.");
+            ui.notifications.warn(localize("LiveManager.ItemNotFound"));
         }
     }
 
@@ -1384,7 +1385,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
             mean = Math.ceil(avg);
         }
 
-        return `(Min: ${min}, Mean: ${mean}, Max: ${max})`;
+        return `(${localize("Common.Min")}: ${min}, ${localize("Common.Mean")}: ${mean}, ${localize("Common.Max")}: ${max})`;
     }
 
     _extractStats(actorData, tier) {
@@ -1413,7 +1414,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                         }
                         
                         if (types.length > 0) {
-                            const typeNames = types.map(t => t.charAt(0).toUpperCase() + t.slice(1));
+            const typeNames = types.map(t => localizeType(t));
                             damageTypesLabel = `(${typeNames.join("/")})`;
                         }
                     }
@@ -1447,7 +1448,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
         }
 
         const isDirect = sys.attack?.damage?.direct ?? false;
-        const directLabel = isDirect ? "Direct: Yes" : "Direct: No";
+        const directLabel = isDirect ? localize("Common.DirectYes") : localize("Common.DirectNo");
 
         return {
             tier,
@@ -1456,7 +1457,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
             stress: sys.resources?.stress?.max,
             thresholds: `${sys.damageThresholds?.major} / ${sys.damageThresholds?.severe}`,
             attackMod: sys.attack?.roll?.bonus,
-            damage: damageParts.join(", ") || "None",
+            damage: damageParts.join(", ") || localize("Common.None"),
             damageTypesLabel: damageTypesLabel, 
             damageStats: this._calculateDamageStats(firstDamageFormula), 
             halvedDamage: halvedParts.join(", ") || null,
@@ -1484,11 +1485,11 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
             suggestionTier = parseInt(this.overrides.suggestedFeaturesTier);
         }
 
-        if (!ADVERSARY_BENCHMARKS[typeKey]) return { stats: { error: "Unknown Type" }, features: [], structuredFeatures: [] };
+        if (!ADVERSARY_BENCHMARKS[typeKey]) return { stats: { error: localize("LiveManager.UnknownType") }, features: [], structuredFeatures: [] };
         
         const benchmark = ADVERSARY_BENCHMARKS[typeKey].tiers[`tier_${targetTier}`];
 
-        if (!benchmark) return { stats: { error: "Benchmark missing" }, features: [], structuredFeatures: [] };
+        if (!benchmark) return { stats: { error: localize("LiveManager.BenchmarkMissing") }, features: [], structuredFeatures: [] };
 
         if (!this._cachedValues) {
             this._cachedValues = {};
@@ -1579,7 +1580,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 if (!currentExpMap[key] && !data.deleted) {
                      activeCount++;
                      const val = data.value !== undefined ? data.value : targetMod;
-                     const name = data.name || "New Experience";
+                     const name = data.name || localize("LiveManager.NewExperience");
                      usedNames.push(name);
                      
                      sim.previewExperiences.push({
@@ -1599,7 +1600,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                     
                     if (!this.overrides.experiences[tempId]) {
                         
-                        let suggestedName = "New Experience";
+                        let suggestedName = localize("LiveManager.NewExperience");
                         if (this._suggestionCache[tempId]) {
                             suggestedName = this._suggestionCache[tempId];
                         } else {
@@ -1694,7 +1695,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 }
             });
         }
-        sim.damage = damageParts.join(", ") || "None";
+        sim.damage = damageParts.join(", ") || localize("Common.None");
         sim.damageStats = this._calculateDamageStats(mainDamageRaw); 
 
         sim.mainDamageRaw = mainDamageRaw;

--- a/scripts/live-manager.js
+++ b/scripts/live-manager.js
@@ -1,4 +1,4 @@
-import { getRollFromRange, getRollFromSignedRange, parseThresholdPair, parseDamageString, processDamageValue, processFeatureUpdate, calculateHitChance, calculateHitChanceAgainst, updateSingleActor } from "./damage-engine.js";
+import { getRollFromRange, getRollFromSignedRange, parseThresholdPair, parseDamageString, processDamageValue, processFeatureUpdate, calculateHitChance, calculateHitChanceAgainst, updateSingleActor, getDamagePartsArray } from "./damage-engine.js";
 import { ADVERSARY_BENCHMARKS, ADVERSARY_EXPERIENCES } from "./rules.js";
 import { MODULE_ID, SETTING_IMPORT_FOLDER, SETTING_EXTRA_COMPENDIUMS, SETTING_FEATURE_COMPENDIUMS, SETTING_LAST_SOURCE, SETTING_LAST_FILTER_TIER, SETTING_SUGGEST_FEATURES, SETTING_OPEN_SHEET_AFTER_APPLY, SKULL_IMAGE_PATH } from "./module.js";
 import { CompendiumManager } from "./compendium-manager.js";
@@ -511,7 +511,7 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
                 
                 if (previewDamageTypes === null) {
                     const actorData = actor.toObject();
-                    const mainPart = actorData.system.attack?.damage?.parts?.[0];
+                    const mainPart = getDamagePartsArray(actorData.system.attack?.damage?.parts)[0];
                     
                     if (mainPart) {
                         if (Array.isArray(mainPart.type)) {
@@ -1104,9 +1104,10 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
             if (this.overrides.damageTypes) {
                 const actorData = freshActor.toObject();
                 const parts = actorData.system.attack?.damage?.parts ? foundry.utils.deepClone(actorData.system.attack.damage.parts) : [];
+                const damageParts = getDamagePartsArray(parts);
                 
-                if (parts && parts.length > 0) {
-                    parts[0].type = this.overrides.damageTypes; 
+                if (damageParts.length > 0) {
+                    damageParts[0].type = this.overrides.damageTypes;
                     manualUpdates["system.attack.damage.parts"] = parts;
                     hasManualUpdates = true;
                 }
@@ -1394,8 +1395,10 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
         let firstHalvedFormula = null;
         let damageTypesLabel = "";
         
-        if (sys.attack?.damage?.parts) {
-            sys.attack.damage.parts.forEach((p, idx) => {
+        const rawDamageParts = sys.attack?.damage?.parts;
+        const actorDamageParts = getDamagePartsArray(rawDamageParts);
+        if (actorDamageParts.length) {
+            actorDamageParts.forEach((p, idx) => {
                 if(p.value) {
                     let formula = p.value.custom?.enabled ? p.value.custom.formula : 
                         (p.value.dice ? `${p.value.flatMultiplier || 1}${p.value.dice}${p.value.bonus ? (p.value.bonus > 0 ? '+'+p.value.bonus : p.value.bonus) : ''}` : p.value.flatMultiplier);
@@ -1638,7 +1641,8 @@ export class LiveManager extends HandlebarsApplicationMixin(ApplicationV2) {
 
         if (actorData.system.attack?.damage?.parts) {
             const tempParts = foundry.utils.deepClone(actorData.system.attack.damage.parts);
-            tempParts.forEach((part, index) => {
+            const tempDamageParts = getDamagePartsArray(tempParts);
+            tempDamageParts.forEach((part, index) => {
                 
                 let rawVal = "";
                 if (this.overrides.damageFormula) {

--- a/scripts/manager.js
+++ b/scripts/manager.js
@@ -2,6 +2,7 @@ const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 import { ADVERSARY_BENCHMARKS } from "./rules.js";
 import { MODULE_ID, SETTING_CHAT_LOG } from "./module.js";
 import { updateSingleActor, sendBatchChatLog } from "./damage-engine.js";
+import { localize } from "./i18n.js";
 
 /**
  * Batch-update application for Daggerheart Adversaries.
@@ -24,7 +25,7 @@ export class Manager extends HandlebarsApplicationMixin(ApplicationV2) {
         id: "daggerheart-adv-manager",
         tag: "form",
         window: {
-            title: "Adversary Manager",
+            title: "DHAM.Windows.AdversaryManager",
             icon: "fas fa-skull",
             resizable: false,
             width: 420
@@ -71,7 +72,7 @@ export class Manager extends HandlebarsApplicationMixin(ApplicationV2) {
 
         const tiers = [1, 2, 3, 4].map(t => ({
             value: t,
-            label: `Tier ${t}`,
+            label: localize("Common.Tier", { tier: t }),
             disabled: !isMixedTier && t === currentSharedTier,
             isCurrent: !isMixedTier && t === currentSharedTier
         }));
@@ -108,6 +109,6 @@ export class Manager extends HandlebarsApplicationMixin(ApplicationV2) {
                 sendBatchChatLog(batchResults, newTier);
             }
             app.close();
-        } else { ui.notifications.info("No Adversaries updated."); }
+        } else { ui.notifications.info(localize("Manager.NoAdversariesUpdated")); }
     }
 }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -7,6 +7,7 @@ import { DiceProbability } from "./dice-probability.js";
 import { EncounterBuilder } from "./encounter-builder.js";
 import { FeatureUpdater } from "./feature-updater.js";
 import { importFeatures } from "./importer.js";
+import { findApplicationById } from "./foundry-compat.js";
 
 // --- Settings Constants ---
 export const MODULE_ID = "daggerheart-advmanager";
@@ -66,7 +67,7 @@ function manage() {
         .filter(a => a && a.type === "adversary");
 
     // CHECK FOR EXISTING WINDOW
-    const existingApp = Object.values(ui.windows).find(w => w.id === "daggerheart-live-preview");
+    const existingApp = findApplicationById("daggerheart-live-preview", LiveManager);
     
     if (existingApp) {
         if (validActors.length === 1) {
@@ -223,7 +224,7 @@ Hooks.on("controlToken", (token, controlled) => {
     const actor = tokens[0].actor;
     if (!actor || actor.type !== "adversary") return;
 
-    const app = Object.values(ui.windows).find(w => w.id === "daggerheart-live-preview");
+    const app = findApplicationById("daggerheart-live-preview", LiveManager);
     if (app) {
         app.updateSelectedActor(actor);
     }
@@ -233,6 +234,7 @@ Hooks.on("renderDaggerheartMenu", (app, html) => {
     if (!game.user.isGM) return;
 
     const element = (html instanceof HTMLElement) ? html : html[0];
+    if (element.querySelector(".dh-adv-tools")) return;
 
     const createBtn = (text, icon, onClick) => {
         const btn = document.createElement("button");
@@ -253,6 +255,7 @@ Hooks.on("renderDaggerheartMenu", (app, html) => {
     const fieldset = element.querySelector("fieldset");
     if (fieldset) {
         const newFieldset = document.createElement("fieldset");
+        newFieldset.classList.add("dh-adv-tools");
         const legend = document.createElement("legend");
         legend.innerText = "Adversary Tools";
         newFieldset.appendChild(legend);
@@ -262,10 +265,14 @@ Hooks.on("renderDaggerheartMenu", (app, html) => {
         newFieldset.appendChild(btnProb); 
         fieldset.after(newFieldset);
     } else {
-        element.appendChild(btnManage);
-        element.appendChild(btnBuilder);
-        element.appendChild(btnStats);
-        element.appendChild(btnProb);
+        const wrapper = document.createElement("div");
+        wrapper.classList.add("dh-adv-tools");
+        wrapper.appendChild(btnManage);
+        wrapper.appendChild(btnBuilder);
+        wrapper.appendChild(btnStats);
+        wrapper.appendChild(btnProb);
+        element.appendChild(wrapper);
+        return;
     }
 });
 
@@ -276,9 +283,11 @@ Hooks.on("renderActorDirectory", (app, html) => {
     const actionButtons = element.querySelector(".header-actions");
     
     if (actionButtons) {
+        if (actionButtons.querySelector(".dh-adv-directory-btn")) return;
+
         const btn = document.createElement("button");
         btn.type = "button";
-        btn.classList.add("create-actor");
+        btn.classList.add("create-actor", "dh-adv-directory-btn");
         btn.style.flex = "0 0 100%";
         btn.style.maxWidth = "100%";
         btn.style.marginTop = "6px";

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -8,6 +8,7 @@ import { EncounterBuilder } from "./encounter-builder.js";
 import { FeatureUpdater } from "./feature-updater.js";
 import { importFeatures } from "./importer.js";
 import { findApplicationById } from "./foundry-compat.js";
+import { localize } from "./i18n.js";
 
 // --- Settings Constants ---
 export const MODULE_ID = "daggerheart-advmanager";
@@ -38,7 +39,7 @@ export const SETTING_OPEN_SHEET_AFTER_APPLY = "openSheetAfterApply";
 function gmOnly(fn) {
     return function (...args) {
         if (!game.user.isGM) {
-            ui.notifications.warn("Only a GM can use this feature.");
+            ui.notifications.warn(localize("Notifications.GmOnly"));
             return;
         }
         return fn.apply(this, args);
@@ -57,7 +58,7 @@ function manage() {
     });
 
     if (brokenToken) {
-        ui.notifications.error(`Error: The token "${brokenToken.name}" references an Actor that no longer exists in the directory.`);
+        ui.notifications.error(localize("Notifications.BrokenToken", { token: brokenToken.name }));
         return;
     }
 
@@ -101,8 +102,8 @@ Hooks.once("init", () => {
     ]);
 
     game.settings.register(MODULE_ID, SETTING_CHAT_LOG, {
-        name: "Log Changes to Chat",
-        hint: "If enabled, sends a whisper to the GM whenever an Adversary is updated via the Manager.",
+        name: localize("Settings.ChatLog.Name"),
+        hint: localize("Settings.ChatLog.Hint"),
         scope: "world",
         config: true,
         type: Boolean,
@@ -110,8 +111,8 @@ Hooks.once("init", () => {
     });
 
     game.settings.register(MODULE_ID, SETTING_UPDATE_EXP, {
-        name: "Auto-Update Experiences",
-        hint: "If enabled, experiences will increase/decrease by 1 for each Tier change.",
+        name: localize("Settings.UpdateExp.Name"),
+        hint: localize("Settings.UpdateExp.Hint"),
         scope: "world",
         config: true,
         type: Boolean,
@@ -119,8 +120,8 @@ Hooks.once("init", () => {
     });
 
     game.settings.register(MODULE_ID, SETTING_ADD_FEATURES, {
-        name: "Auto-Add Features on Tier Up",
-        hint: "If enabled, randomly suggests adding features when leveling up.",
+        name: localize("Settings.AddFeatures.Name"),
+        hint: localize("Settings.AddFeatures.Hint"),
         scope: "world",
         config: true,
         type: Boolean,
@@ -128,8 +129,8 @@ Hooks.once("init", () => {
     });
 
     game.settings.register(MODULE_ID, SETTING_SUGGEST_FEATURES, {
-        name: "Enable Suggested Features",
-        hint: "If enabled, shows the 'New Suggested Features' section in the Live Manager preview.",
+        name: localize("Settings.SuggestFeatures.Name"),
+        hint: localize("Settings.SuggestFeatures.Hint"),
         scope: "world",
         config: true,
         type: Boolean,
@@ -137,25 +138,25 @@ Hooks.once("init", () => {
     });
 
     game.settings.register(MODULE_ID, SETTING_IMPORT_FOLDER, {
-        name: "Compendium Import Folder",
-        hint: "Name of the folder where adversaries imported from Compendiums will be created.",
+        name: localize("Settings.ImportFolder.Name"),
+        hint: localize("Settings.ImportFolder.Hint"),
         scope: "world",
         config: true,
         type: String,
-        default: "💀 Imported Adversaries"
+        default: localize("Defaults.ImportedAdversaries")
     });
 
     game.settings.register(MODULE_ID, SETTING_ENCOUNTER_FOLDER, {
-        name: "Encounter Folder Name",
-        hint: "Name of the root folder where encounters created by the builder will be stored.",
+        name: localize("Settings.EncounterFolder.Name"),
+        hint: localize("Settings.EncounterFolder.Hint"),
         scope: "world",
         config: true,
         type: String,
-        default: "💀 My Encounters"
+        default: localize("Defaults.MyEncounters")
     });
 
     game.settings.register(MODULE_ID, SETTING_EXTRA_COMPENDIUMS, {
-        name: "Extra Compendiums (Actors)",
+        name: localize("Settings.ExtraCompendiums.Name"),
         scope: "world",
         config: false,
         type: Array,
@@ -163,7 +164,7 @@ Hooks.once("init", () => {
     });
 
     game.settings.register(MODULE_ID, SETTING_FEATURE_COMPENDIUMS, {
-        name: "Feature Compendiums",
+        name: localize("Settings.FeatureCompendiums.Name"),
         scope: "world",
         config: false,
         type: Array,
@@ -172,7 +173,7 @@ Hooks.once("init", () => {
 
     // --- REGISTRO DA CONFIGURAÇÃO DE STATS ---
     game.settings.register(MODULE_ID, SETTING_STATS_COMPENDIUMS, {
-        name: "Stats Compendiums",
+        name: localize("Settings.StatsCompendiums.Name"),
         scope: "world",
         config: false,
         type: Array,
@@ -247,17 +248,17 @@ Hooks.on("renderDaggerheartMenu", (app, html) => {
         return btn;
     };
 
-    const btnManage = createBtn("Manage Adversaries", "fa-skull", manage);
-    const btnStats = createBtn("Compendium Stats", "fa-chart-pie", () => new CompendiumStats().render(true));
-    const btnProb = createBtn("Dice Probability", "fa-dice-d20", () => new DiceProbability().render(true));
-    const btnBuilder = createBtn("Encounter Builder", "fa-dungeon", () => new EncounterBuilder().render(true));
+    const btnManage = createBtn(localize("ModuleMenu.ManageAdversaries"), "fa-skull", manage);
+    const btnStats = createBtn(localize("ModuleMenu.CompendiumStats"), "fa-chart-pie", () => new CompendiumStats().render(true));
+    const btnProb = createBtn(localize("ModuleMenu.DiceProbability"), "fa-dice-d20", () => new DiceProbability().render(true));
+    const btnBuilder = createBtn(localize("ModuleMenu.EncounterBuilder"), "fa-dungeon", () => new EncounterBuilder().render(true));
 
     const fieldset = element.querySelector("fieldset");
     if (fieldset) {
         const newFieldset = document.createElement("fieldset");
         newFieldset.classList.add("dh-adv-tools");
         const legend = document.createElement("legend");
-        legend.innerText = "Adversary Tools";
+        legend.innerText = localize("ModuleMenu.AdversaryTools");
         newFieldset.appendChild(legend);
         newFieldset.appendChild(btnManage);
         newFieldset.appendChild(btnBuilder);
@@ -291,7 +292,7 @@ Hooks.on("renderActorDirectory", (app, html) => {
         btn.style.flex = "0 0 100%";
         btn.style.maxWidth = "100%";
         btn.style.marginTop = "6px";
-        btn.innerHTML = `<i class="fas fa-skull"></i> Manage Adversaries`;
+        btn.innerHTML = `<i class="fas fa-skull"></i> ${localize("ModuleMenu.ManageAdversaries")}`;
         
         btn.addEventListener("click", (e) => {
             e.preventDefault();

--- a/templates/compendium-manager.hbs
+++ b/templates/compendium-manager.hbs
@@ -1,18 +1,18 @@
 <div class="dh-adv-manager-content">
     <div class="status-header">
-        <h3>Select Available Compendiums</h3>
+        <h3>{{localize "DHAM.CompendiumManager.SelectAvailableCompendiums"}}</h3>
         <p style="font-size: 0.8em; color: #aaa; margin-top: 5px;">
-            Choose compendiums to be used as sources.
+            {{localize "DHAM.CompendiumManager.ChooseCompendiums"}}
         </p>
     </div>
 
     <!-- Navigation Tabs -->
     <nav class="dh-tabs">
         <a class="dh-tab-link active" data-tab="actors">
-            <i class="fas fa-users"></i> Actors
+            <i class="fas fa-users"></i> {{localize "DHAM.CompendiumManager.Actors"}}
         </a>
         <a class="dh-tab-link" data-tab="features">
-            <i class="fas fa-suitcase"></i> Features
+            <i class="fas fa-suitcase"></i> {{localize "DAGGERHEART.GENERAL.features"}}
         </a>
     </nav>
 
@@ -33,7 +33,7 @@
                     </div>
                     {{/each}}
                 {{else}}
-                    <p class="empty-msg">No other Actor compendiums found.</p>
+                    <p class="empty-msg">{{localize "DHAM.CompendiumManager.NoActorCompendiums"}}</p>
                 {{/if}}
             </div>
         </div>
@@ -52,7 +52,7 @@
                     </div>
                     {{/each}}
                 {{else}}
-                    <p class="empty-msg">No Item compendiums found.</p>
+                    <p class="empty-msg">{{localize "DHAM.CompendiumManager.NoItemCompendiums"}}</p>
                 {{/if}}
             </div>
         </div>
@@ -61,7 +61,7 @@
 
     <footer class="sheet-footer">
         <button type="submit">
-            <i class="fas fa-save"></i> Save Selection
+            <i class="fas fa-save"></i> {{localize "DHAM.CompendiumManager.SaveSelection"}}
         </button>
     </footer>
 </div>

--- a/templates/compendium-stats-manager.hbs
+++ b/templates/compendium-stats-manager.hbs
@@ -2,13 +2,12 @@
 
     <!-- Header with Warning -->
     <div class="status-header">
-        <h3>Select Stat Sources</h3>
+        <h3>{{localize "DHAM.StatsManager.SelectStatSources"}}</h3>
         <div class="csm-warning-box">
             <p class="csm-warning-text">
-                <i class="fas fa-exclamation-triangle"></i> <strong>Important:</strong>
-                Selecting a new compendium will trigger an automated import process.
-                Features from the selected actors will be copied to your world items.
-                <strong>Please wait for the import notification to finish.</strong>
+                <i class="fas fa-exclamation-triangle"></i> <strong>{{localize "DHAM.StatsManager.Important"}}</strong>
+                {{localize "DHAM.StatsManager.ImportNote"}}
+                <strong>{{localize "DHAM.StatsManager.WaitImport"}}</strong>
             </p>
         </div>
     </div>
@@ -32,18 +31,18 @@
 
                     <!-- Custom Tag Input -->
                     <div class="csm-input-col csm-tag-col">
-                        <input type="text" name="tag_{{this.id}}" placeholder="Tag (Def: Label)" class="csm-input">
+                        <input type="text" name="tag_{{this.id}}" placeholder="{{localize "DHAM.StatsManager.TagPlaceholder"}}" class="csm-input">
                     </div>
 
                     <!-- Custom Folder Input -->
                     <div class="csm-input-col csm-folder-col">
-                        <input type="text" name="folder_{{this.id}}" placeholder="Folder (Def: Imported...)" class="csm-input">
+                        <input type="text" name="folder_{{this.id}}" placeholder="{{localize "DHAM.StatsManager.FolderPlaceholder"}}" class="csm-input">
                     </div>
 
                 </div>
                 {{/each}}
             {{else}}
-                <p class="empty-msg">No other Actor compendiums found.</p>
+                <p class="empty-msg">{{localize "DHAM.CompendiumManager.NoActorCompendiums"}}</p>
             {{/if}}
         </div>
 
@@ -51,7 +50,7 @@
 
     <footer class="sheet-footer">
         <button type="submit">
-            <i class="fas fa-save"></i> Save Selection & Import
+            <i class="fas fa-save"></i> {{localize "DHAM.StatsManager.SaveSelectionImport"}}
         </button>
     </footer>
 </div>

--- a/templates/compendium-stats.hbs
+++ b/templates/compendium-stats.hbs
@@ -2,11 +2,11 @@
     {{#if loading}}
         <div class="loading-state" style="text-align: center; padding: 20px;">
             <i class="fas fa-spinner fa-spin fa-3x"></i>
-            <p>Reading Compendium Data...</p>
+            <p>{{localize "DHAM.CompendiumStats.ReadingData"}}</p>
         </div>
     {{else}}
         <div class="form-group stats-controls">
-            <label style="font-weight: bold; font-size: 1.2em;">Adversary Type:</label>
+            <label style="font-weight: bold; font-size: 1.2em;">{{localize "DHAM.CompendiumStats.AdversaryType"}}</label>
             <div class="select-wrapper" style="flex: 1;">
                 <select class="stats-type-select">
                     {{#each typeOptions}}
@@ -17,12 +17,12 @@
             </div>
             
             <!-- Settings Button -->
-            <button type="button" class="settings-btn" data-action="openSettings" data-tooltip="Manage Stat Sources">
+            <button type="button" class="settings-btn" data-action="openSettings" data-tooltip="{{localize "DHAM.CompendiumStats.ManageStatSources"}}">
                 <i class="fas fa-cog"></i>
             </button>
             
             <!-- Refresh Button -->
-            <button type="button" class="settings-btn" data-action="refresh" data-tooltip="Refresh Stats">
+            <button type="button" class="settings-btn" data-action="refresh" data-tooltip="{{localize "DHAM.CompendiumStats.RefreshStats"}}">
                 <i class="fas fa-sync-alt"></i>
             </button>
         </div>
@@ -31,7 +31,7 @@
             <table class="dh-stats-table">
                 <thead>
                     <tr>
-                        <th class="col-type">Type</th>
+                        <th class="col-type">{{localize "DAGGERHEART.GENERAL.type"}}</th>
                         {{#each headers}}
                         <th>{{this}}</th>
                         {{/each}}

--- a/templates/dice-probability.hbs
+++ b/templates/dice-probability.hbs
@@ -7,14 +7,14 @@
                 data-action="setMode"
                 data-value="duality"
                 class="roll-btn {{#if isDualityMode}}active{{/if}}"
-                title="Duality Dice (2d12)">
-                <i class="fas fa-dice"></i> Duality Dice
+                title="{{localize "DAGGERHEART.GENERAL.dualityDice"}} (2d12)">
+                <i class="fas fa-dice"></i> {{localize "DAGGERHEART.GENERAL.dualityDice"}}
             </button>
             <button type="button"
                 data-action="setMode"
                 data-value="d20"
                 class="roll-btn {{#if isD20Mode}}active{{/if}}"
-                title="D20 System">
+                title="{{localize "DHAM.DiceProbability.D20System"}}">
                 <i class="fas fa-dice-d20"></i> D20
             </button>
         </div>
@@ -27,7 +27,7 @@
 
         <!-- Die 1 Buttons -->
         <div class="stat-row">
-            <span class="stat-label">Die 1</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.Dice.plural"}} 1</span>
             <div class="die-btn-group">
                 {{#each die1Buttons}}
                 <button type="button"
@@ -42,7 +42,7 @@
 
         <!-- Die 2 Buttons -->
         <div class="stat-row">
-            <span class="stat-label">Die 2</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.Dice.plural"}} 2</span>
             <div class="die-btn-group">
                 {{#each die2Buttons}}
                 <button type="button"
@@ -55,7 +55,7 @@
             </div>
         </div>
 
-        {{> "modules/daggerheart-advmanager/templates/partials/dp-roll-type.hbs" disTitle="Disadvantage" normTitle="Normal" advTitle="Advantage"}}
+        {{> "modules/daggerheart-advmanager/templates/partials/dp-roll-type.hbs" disTitle=(localize "DAGGERHEART.GENERAL.Disadvantage.full") normTitle=(localize "DHAM.DiceProbability.Normal") advTitle=(localize "DAGGERHEART.GENERAL.Advantage.full")}}
 
         <!-- Advantage Die Selection (Conditionally Visible or Disabled) -->
         <div class="stat-row {{#unless showAdvDie}}dp-disabled-row{{/unless}}">
@@ -75,11 +75,11 @@
         {{else}}
         <!-- ========== D20 MODE ========== -->
 
-        {{> "modules/daggerheart-advmanager/templates/partials/dp-roll-type.hbs" disTitle="Disadvantage (2d20 keep lowest)" normTitle="Normal (1d20)" advTitle="Advantage (2d20 keep highest)"}}
+        {{> "modules/daggerheart-advmanager/templates/partials/dp-roll-type.hbs" disTitle=(localize "DHAM.DiceProbability.DisadvantageD20") normTitle=(localize "DHAM.DiceProbability.NormalD20") advTitle=(localize "DHAM.DiceProbability.AdvantageD20")}}
 
         <!-- Critical Threshold -->
         <div class="stat-row">
-            <span class="stat-label">Critical Threshold</span>
+            <span class="stat-label">{{localize "DAGGERHEART.ACTIONS.Settings.criticalThreshold"}}</span>
             <div class="select-wrapper dp-select-wrapper">
                 <select name="criticalThreshold" class="stats-type-select">
                     {{#each critOptions}}
@@ -96,7 +96,7 @@
 
         <!-- Modifier Input -->
         <div class="stat-row">
-            <span class="stat-label">Modifier (+/-)</span>
+            <span class="stat-label">{{localize "DHAM.DiceProbability.Modifier"}}</span>
             <div class="dp-input-wrapper">
                 <input type="number" name="modifier" class="stats-type-select dp-modifier-input" value="{{currentModifier}}" placeholder="0">
             </div>
@@ -104,7 +104,7 @@
 
         <!-- Difficulty -->
         <div class="stat-row">
-            <span class="stat-label">Difficulty</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.difficulty"}}</span>
             <div class="select-wrapper dp-select-wrapper">
                 <select name="difficulty" class="stats-type-select">
                     {{#each diffOptions}}
@@ -119,28 +119,28 @@
 
     <!-- Results Section -->
     <div class="probability-results dp-results">
-        <h3 class="dp-results-header">Results</h3>
+        <h3 class="dp-results-header">{{localize "DAGGERHEART.GENERAL.result.plural"}}</h3>
 
         <div class="stat-row">
-            <span class="stat-label">Roll</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.roll"}}</span>
             <span class="stat-value dp-roll-notation">{{results.diceNotation}}</span>
         </div>
 
         <div class="stat-row dp-result-row-border">
-            <span class="stat-label dp-color-success">Success Chance</span>
+            <span class="stat-label dp-color-success">{{localize "DHAM.DiceProbability.SuccessChance"}}</span>
             <span class="stat-value dp-color-success dp-result-bold">{{results.success}}%</span>
         </div>
 
         <div class="stat-row">
-            <span class="stat-label dp-color-fail">Failure Chance</span>
+            <span class="stat-label dp-color-fail">{{localize "DHAM.DiceProbability.FailureChance"}}</span>
             <span class="stat-value dp-color-fail">{{results.fail}}%</span>
         </div>
 
         <div class="stat-row">
             {{#if isDualityMode}}
-            <span class="stat-label dp-color-crit">Critical (Doubles)</span>
+            <span class="stat-label dp-color-crit">{{localize "DHAM.DiceProbability.CriticalDoubles"}}</span>
             {{else}}
-            <span class="stat-label dp-color-crit">Critical ({{results.criticalThreshold}}+)</span>
+            <span class="stat-label dp-color-crit">{{localize "DAGGERHEART.GENERAL.criticalShort"}} ({{results.criticalThreshold}}+)</span>
             {{/if}}
             <span class="stat-value dp-color-crit">{{results.crit}}%</span>
         </div>
@@ -148,7 +148,7 @@
 
     <footer class="sheet-footer dp-footer">
         <button type="button" data-action="sendToChat" class="dp-chat-btn">
-            <i class="fas fa-comment-dots"></i> Send to Chat
+            <i class="fas fa-comment-dots"></i> {{localize "DAGGERHEART.UI.Tooltip.sendToChat"}}
         </button>
     </footer>
 

--- a/templates/encounter-builder.hbs
+++ b/templates/encounter-builder.hbs
@@ -7,7 +7,7 @@
             <!-- Search -->
             <div class="eb-search-wrapper">
                 <i class="fas fa-search search-icon"></i>
-                <input type="text" class="eb-search-input" placeholder="Search adversaries..." value="{{searchQuery}}">
+                <input type="text" class="eb-search-input" placeholder="{{localize "DHAM.EncounterBuilder.SearchPlaceholder"}}" value="{{searchQuery}}">
                 {{#if searchQuery}}
                 <button type="button" data-action="clearSearch" class="clear-btn"><i class="fas fa-times"></i></button>
                 {{/if}}
@@ -47,7 +47,7 @@
         </div>
 
         <div class="eb-results-header">
-            Library ({{resultCount}})
+            {{localize "DHAM.EncounterBuilder.Library" count=resultCount}}
         </div>
 
         <div class="eb-results-list">
@@ -56,12 +56,12 @@
                 
                 <div class="eb-row-actions-left">
                     <!-- Add Button -->
-                    <button type="button" class="eb-add-btn" data-action="addUnit" title="Add to Encounter">
+                    <button type="button" class="eb-add-btn" data-action="addUnit" title="{{localize "DHAM.EncounterBuilder.AddToEncounter"}}">
                         <i class="fas fa-plus"></i>
                     </button>
 
                     <!-- Edit Button -->
-                    <button type="button" class="eb-edit-btn" data-action="editAdversary" title="Edit in Live Manager">
+                    <button type="button" class="eb-edit-btn" data-action="editAdversary" title="{{localize "DHAM.EncounterBuilder.EditLiveManager"}}">
                         <i class="fas fa-sliders-h"></i>
                     </button>
                 </div>
@@ -74,9 +74,9 @@
                             <div class="eb-row-name">{{this.name}}</div>
                         </div>
                         <div class="eb-row-meta">
-                            <span class="eb-type-tag">{{this.type}}</span>
+                            <span class="eb-type-tag">{{this.typeLabel}}</span>
                             {{#if this.isCompendium}}
-                            <i class="fas fa-book eb-compendium-icon" title="Compendium"></i>
+                            <i class="fas fa-book eb-compendium-icon" title="{{localize "DHAM.Common.Compendium"}}"></i>
                             {{/if}}
                             {{#each this.specialFeatures}}
                                 <span class="feature-tag">{{this}}</span>
@@ -90,7 +90,7 @@
             </div>
             {{else}}
             <div class="empty-state">
-                <p>No adversaries found.</p>
+                <p>{{localize "DHAM.EncounterBuilder.NoAdversariesFound"}}</p>
             </div>
             {{/each}}
         </div>
@@ -104,7 +104,7 @@
             <!-- Grouped Row: PC, Tier (moved left), Fear (moved right) -->
             <div class="eb-settings-row-group">
                 <div class="eb-setting-col pc-col">
-                    <label># PCs:</label>
+                    <label>{{localize "DHAM.EncounterBuilder.PCs"}}</label>
                     <div class="select-wrapper mini">
                         <select class="pc-count-select">
                             {{#each pcCountOptions}}
@@ -116,7 +116,7 @@
                 
                 <!-- Moved Tier to Left -->
                 <div class="eb-setting-col tier-col">
-                    <label>Party Tier:</label>
+                    <label>{{localize "DHAM.EncounterBuilder.PartyTier"}}</label>
                     <div class="select-wrapper mini">
                         <select class="pc-tier-select">
                             {{#each pcTierOptions}}
@@ -128,8 +128,8 @@
 
                 <!-- Moved Fear to Right -->
                 <div class="eb-setting-col fear-col">
-                    <label title="Spending more Fear increases the perceived difficulty level.">
-                        Fear Budget: <i class="fas fa-question-circle eb-hint-icon"></i>
+                    <label title="{{localize "DHAM.EncounterBuilder.FearHint"}}">
+                        {{localize "DHAM.EncounterBuilder.FearBudget"}} <i class="fas fa-question-circle eb-hint-icon"></i>
                     </label>
                     <div class="select-wrapper mini">
                         <select class="pc-fear-select">
@@ -149,18 +149,18 @@
             <!-- 1. BP Calculation Header -->
             <div class="eb-bp-header">
                 <div class="bp-stat">
-                    <span class="bp-label">Budget Limit</span>
+                    <span class="bp-label">{{localize "DHAM.EncounterBuilder.BudgetLimit"}}</span>
                     <span class="bp-value">{{bpData.total}}</span>
-                    <div class="bp-sub-badge">Base: {{bpData.base}}</div>
+                    <div class="bp-sub-badge">{{localize "DHAM.Common.Base" base=bpData.base}}</div>
                 </div>
                 
                 <!-- Dynamic Skull Image -->
                 <div class="bp-skull-container">
-                    <img src="{{bpData.skullImage}}" class="bp-skull-img" alt="Difficulty Skull">
+                    <img src="{{bpData.skullImage}}" class="bp-skull-img" alt="{{localize "DAGGERHEART.GENERAL.difficulty"}}">
                 </div>
 
                 <div class="bp-stat">
-                    <span class="bp-label">Current Cost</span>
+                    <span class="bp-label">{{localize "DHAM.EncounterBuilder.CurrentCost"}}</span>
                     <span class="bp-value cost-{{bpData.statusColor}}">{{bpData.cost}}</span>
                     <div class="bp-difficulty {{bpData.difficultyClass}}">{{bpData.difficultyLabel}}</div>
                 </div>
@@ -168,16 +168,16 @@
 
             <!-- 2. Synergy/Feature Icons Grid (20% Width) -->
             <div class="eb-synergy-grid">
-                <div class="synergy-item {{#if synergy.summoner}}active{{/if}}" data-tooltip="There are adversaries capable of summoning other adversaries.">
+                <div class="synergy-item {{#if synergy.summoner}}active{{/if}}" data-tooltip="{{localize "DHAM.EncounterBuilder.SynergySummoner"}}">
                     <img src="icons/environment/people/charge.webp" class="synergy-icon">
                 </div>
-                <div class="synergy-item {{#if synergy.spotlighter}}active{{/if}}" data-tooltip="There are adversaries capable of spotlighting other adversaries.">
+                <div class="synergy-item {{#if synergy.spotlighter}}active{{/if}}" data-tooltip="{{localize "DHAM.EncounterBuilder.SynergySpotlighter"}}">
                     <img src="icons/skills/movement/arrows-up-trio-red.webp" class="synergy-icon">
                 </div>
-                <div class="synergy-item {{#if synergy.momentum}}active{{/if}}" data-tooltip="There are adversaries capable of gaining Fear.">
+                <div class="synergy-item {{#if synergy.momentum}}active{{/if}}" data-tooltip="{{localize "DHAM.EncounterBuilder.SynergyMomentum"}}">
                     <img src="icons/skills/melee/strike-weapons-orange.webp" class="synergy-icon">
                 </div>
-                <div class="synergy-item {{#if synergy.relentless}}active{{/if}}" data-tooltip="There are adversaries that can be spotlighted multiple times per GM turn.">
+                <div class="synergy-item {{#if synergy.relentless}}active{{/if}}" data-tooltip="{{localize "DHAM.EncounterBuilder.SynergyRelentless"}}">
                     <img src="icons/magic/unholy/silhouette-evil-horned-giant.webp" class="synergy-icon">
                 </div>
             </div>
@@ -206,10 +206,10 @@
         <div class="eb-encounter-list-wrapper">
             <!-- Header Container with Flexbox for Alignment -->
             <div class="eb-results-header eb-encounter-header-row">
-                <span>Adversaries ({{encounterCount}})</span>
+                <span>{{localize "DAGGERHEART.GENERAL.Adversary.plural"}} ({{encounterCount}})</span>
                 {{#if encounterCount}}
                 <button type="button" data-action="clearEncounter" class="eb-clear-btn">
-                    <i class="fas fa-trash-alt"></i> Clear All
+                    <i class="fas fa-trash-alt"></i> {{localize "DHAM.EncounterBuilder.ClearAll"}}
                 </button>
                 {{/if}}
             </div>
@@ -227,7 +227,7 @@
                                 <div class="eb-row-name">{{this.name}}</div>
                             </div>
                             <div class="eb-row-meta">
-                                <span class="eb-type-tag">{{this.type}}</span>
+                                <span class="eb-type-tag">{{this.typeLabel}}</span>
                                 <!-- Tier removed from here -->
                                 
                                 <!-- Special Features Display (Right) -->
@@ -254,7 +254,7 @@
                 </div>
                 {{else}}
                 <div class="empty-state small">
-                    <p>Add units from the library.</p>
+                    <p>{{localize "DHAM.EncounterBuilder.AddUnits"}}</p>
                 </div>
                 {{/each}}
             </div>
@@ -270,11 +270,11 @@
 
             <!-- Create Button (Center/Main) -->
             <button type="button" class="eb-create-btn" data-action="createEncounter">
-                <i class="fas fa-folder-plus"></i> Create Encounter
+                <i class="fas fa-folder-plus"></i> {{localize "DHAM.EncounterBuilder.CreateEncounter"}}
             </button>
             
             <!-- Place Button (Right) -->
-            <button type="button" class="eb-place-btn" data-action="placeEncounter" title="Create & Place Invisible">
+            <button type="button" class="eb-place-btn" data-action="placeEncounter" title="{{localize "DHAM.EncounterBuilder.CreateAndPlaceInvisible"}}">
                 <i class="fas fa-street-view"></i>
             </button>
         </div>

--- a/templates/feature-updater.hbs
+++ b/templates/feature-updater.hbs
@@ -1,7 +1,7 @@
 <div class="dh-adv-manager-content feature-updater-container">
 
     <div class="form-group" style="margin-bottom: 15px;">
-        <label class="drop-label">1. Drop Feature Here</label>
+        <label class="drop-label">{{localize "DHAM.FeatureUpdater.DropFeature"}}</label>
         <div class="drop-zone {{#if item}}has-item{{/if}}">
             {{#if item}}
                 <div class="dropped-item-content">
@@ -11,7 +11,7 @@
             {{else}}
                 <div class="drop-placeholder">
                     <i class="fas fa-box-open drop-icon-placeholder"></i>
-                    <span>Drag a Feature from the World</span>
+                    <span>{{localize "DHAM.FeatureUpdater.DragFeature"}}</span>
                 </div>
             {{/if}}
         </div>
@@ -20,10 +20,10 @@
     <hr class="updater-divider">
 
     <div class="form-group">
-        <label>2. Configure Flags</label>
+        <label>{{localize "DHAM.FeatureUpdater.ConfigureFlags"}}</label>
 
         <div class="form-field">
-            <label>Target Tier</label>
+            <label>{{localize "DHAM.FeatureUpdater.TargetTier"}}</label>
             <select name="tier" class="updater-input">
                 {{#each tierOptions}}
                 <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
@@ -32,7 +32,7 @@
         </div>
 
         <div class="form-field">
-            <label>Adversary Type</label>
+            <label>{{localize "DHAM.FeatureUpdater.AdversaryType"}}</label>
             <select name="type" class="updater-input">
                 {{#each typeOptions}}
                 <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
@@ -41,14 +41,14 @@
         </div>
 
         <div class="form-field">
-            <label>Custom Tag</label>
-            <input type="text" name="customTag" value="{{customTagValue}}" class="updater-input" placeholder="e.g. Core, Homebrew">
+            <label>{{localize "DHAM.FeatureUpdater.CustomTag"}}</label>
+            <input type="text" name="customTag" value="{{customTagValue}}" class="updater-input" placeholder="{{localize "DHAM.FeatureUpdater.CustomTagPlaceholder"}}">
         </div>
     </div>
 
     <footer class="sheet-footer updater-footer">
         <button type="submit" class="apply-btn" {{#unless item}}disabled{{/unless}}>
-            <i class="fas fa-save"></i> Update Feature Flags
+            <i class="fas fa-save"></i> {{localize "DHAM.FeatureUpdater.UpdateFlags"}}
         </button>
     </footer>
 </div>

--- a/templates/live-manager.hbs
+++ b/templates/live-manager.hbs
@@ -7,7 +7,7 @@
     <!-- Tier Selection Tabs -->
     <div class="tier-tabs">
         <div class="tier-control-row">
-            <label class="tier-control-label">Target Tier:</label>
+            <label class="tier-control-label">{{localize "DHAM.LiveManager.TargetTier"}}</label>
             <div class="tier-buttons tier-buttons-flush">
                 {{#each tiers}}
                 <button type="button"
@@ -34,12 +34,12 @@
         <div class="footer-row">
             <button type="button" data-action="applyChanges" class="apply-btn">
                 {{#if (eq linkData null)}}
-                    <i class="fas fa-file-import"></i> Import & Apply Tier {{previewStats.tier}}
+                    <i class="fas fa-file-import"></i> {{localize "DHAM.LiveManager.ImportApplyTier" tier=previewStats.tier}}
                 {{else}}
-                    <i class="fas fa-bolt"></i> Apply Tier {{previewStats.tier}} to {{actorName}}
+                    <i class="fas fa-bolt"></i> {{localize "DHAM.LiveManager.ApplyTierToActor" tier=previewStats.tier actor=actorName}}
                 {{/if}}
             </button>
-            <button type="button" data-action="toggleOpenSheet" class="open-sheet-toggle {{#if openAfterApply}}active{{/if}}" title="Open sheet after applying">
+            <button type="button" data-action="toggleOpenSheet" class="open-sheet-toggle {{#if openAfterApply}}active{{/if}}" title="{{localize "DHAM.LiveManager.OpenSheetAfterApplying"}}">
                 <i class="fas fa-external-link-alt"></i>
             </button>
         </div>
@@ -48,7 +48,7 @@
     {{else}}
     <div class="empty-state">
         <i class="fas fa-skull empty-state-icon"></i>
-        <p>Select an Adversary from the list above to begin preview.</p>
+        <p>{{localize "DHAM.LiveManager.SelectAdversaryPrompt"}}</p>
     </div>
     {{/if}}
 

--- a/templates/manager.hbs
+++ b/templates/manager.hbs
@@ -1,7 +1,7 @@
 <div class="dh-adv-manager-content">
 
 <div class="status-header">
-    <h3>Selected Adversaries</h3>
+    <h3>{{localize "DHAM.Manager.SelectedAdversaries"}}</h3>
 </div>
 
 <!-- Scrollable Actor List -->
@@ -11,14 +11,14 @@
         <span class="actor-name">{{this.name}}</span>
         <div class="actor-badges">
             <span class="badge-tier">T{{this.tier}}</span>
-            <i class="fas {{this.linkIcon}} {{this.linkClass}}" title="{{#if this.isLinked}}Linked{{else}}Unlinked{{/if}}"></i>
+            <i class="fas {{this.linkIcon}} {{this.linkClass}}" title="{{#if this.isLinked}}{{localize "DHAM.Common.Linked"}}{{else}}{{localize "DHAM.Common.Unlinked"}}{{/if}}"></i>
         </div>
     </div>
     {{/each}}
 </div>
 
 <div class="form-group" style="margin-top: 10px;">
-    <label>Select Target Tier:</label>
+    <label>{{localize "DHAM.Manager.SelectTargetTier"}}</label>
     
     <div class="tier-selector">
         {{#each tiers}}
@@ -35,7 +35,7 @@
 
 <footer class="sheet-footer">
     <button type="submit">
-        <i class="fas fa-save"></i> Apply Changes
+        <i class="fas fa-save"></i> {{localize "DHAM.Common.ApplyChanges"}}
     </button>
 </footer>
 

--- a/templates/partials/dp-roll-type.hbs
+++ b/templates/partials/dp-roll-type.hbs
@@ -1,27 +1,27 @@
 <!-- Roll Type Buttons (Dis/Norm/Adv) -->
 <div class="stat-row">
-    <span class="stat-label">Roll Type</span>
+    <span class="stat-label">{{localize "DAGGERHEART.APPLICATIONS.TagTeamSelect.rollType"}}</span>
     <div class="roll-type-buttons dp-roll-type">
         <button type="button"
             data-action="setRollType"
             data-value="-1"
             class="roll-btn {{#if isDisadvantage}}active{{/if}}"
             title="{{disTitle}}">
-            Dis
+            {{localize "DAGGERHEART.GENERAL.Disadvantage.short"}}
         </button>
         <button type="button"
             data-action="setRollType"
             data-value="0"
             class="roll-btn {{#if isNormal}}active{{/if}}"
             title="{{normTitle}}">
-            Norm
+            {{localize "DHAM.DiceProbability.Norm"}}
         </button>
         <button type="button"
             data-action="setRollType"
             data-value="1"
             class="roll-btn {{#if isAdvantage}}active{{/if}}"
             title="{{advTitle}}">
-            Adv
+            {{localize "DAGGERHEART.GENERAL.Advantage.short"}}
         </button>
     </div>
 </div>

--- a/templates/partials/lm-controls.hbs
+++ b/templates/partials/lm-controls.hbs
@@ -11,7 +11,7 @@
             <i class="fas fa-database select-arrow"></i>
         </div>
 
-        <button type="button" data-action="openSettings" class="settings-btn" title="Manage Compendiums">
+        <button type="button" data-action="openSettings" class="settings-btn" title="{{localize "DHAM.LiveManager.ManageCompendiums"}}">
             <i class="fas fa-cog"></i>
         </button>
 
@@ -35,7 +35,7 @@
 
         <div class="select-wrapper actor-wrapper">
             <select name="actorSelect" class="main-actor-select">
-                <option value="" disabled {{#unless selectedActorId}}selected{{/unless}}>-- Choose an Adversary --</option>
+                <option value="" disabled {{#unless selectedActorId}}selected{{/unless}}>{{localize "DHAM.Common.ChooseAdversary"}}</option>
                 {{#each adversaries}}
                 <option value="{{this.id}}" {{#if this.selected}}selected{{/if}}>{{this.name}}</option>
                 {{/each}}
@@ -43,11 +43,11 @@
             <i class="fas fa-chevron-down select-arrow"></i>
         </div>
 
-        <button type="button" data-action="openStats" class="settings-btn" title="Compendium Stats">
+        <button type="button" data-action="openStats" class="settings-btn" title="{{localize "DHAM.ModuleMenu.CompendiumStats"}}">
             <i class="fas fa-chart-pie"></i>
         </button>
 
-        <button type="button" data-action="openDiceProb" class="settings-btn" title="Dice Probability">
+        <button type="button" data-action="openDiceProb" class="settings-btn" title="{{localize "DHAM.ModuleMenu.DiceProbability"}}">
             <i class="fas fa-dice-d20"></i>
         </button>
     </div>

--- a/templates/partials/lm-current-stats.hbs
+++ b/templates/partials/lm-current-stats.hbs
@@ -1,14 +1,14 @@
 <!-- Left Column: Current State -->
 <div class="preview-column current-column current-column-start">
     <h3 class="col-header">
-        Current (T{{currentStats.tier}})
+        {{localize "DAGGERHEART.UI.Chat.damageRoll.currentTarget"}} (T{{currentStats.tier}})
         {{#if linkData}}
             <i class="fas {{linkData.icon}} {{linkData.cssClass}} lm-link-icon" title="{{linkData.label}}"></i>
         {{/if}}
     </h3>
 
     <div class="stat-row">
-        <span class="stat-label">Difficulty</span>
+        <span class="stat-label">{{localize "DAGGERHEART.GENERAL.difficulty"}}</span>
         <span class="stat-value">
             {{#if currentStats.hitChanceAgainst}}
                 <span class="lm-hit-chance-hint" title="{{currentStats.hitChanceAgainst.tooltip}}">{{currentStats.hitChanceAgainst.text}}</span>
@@ -20,22 +20,22 @@
     <!-- HP & STRESS ROW (CURRENT) -->
     <div class="stat-row-dual">
         <div class="stat-col-half">
-            <span class="stat-label">HP</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.HitPoints.short"}}</span>
             <span class="stat-value">{{currentStats.hp}}</span>
         </div>
         <div class="stat-separator"></div>
         <div class="stat-col-half">
-            <span class="stat-label">Stress</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.stress"}}</span>
             <span class="stat-value">{{currentStats.stress}}</span>
         </div>
     </div>
 
     <div class="stat-row">
-        <span class="stat-label">Thresholds</span>
+        <span class="stat-label">{{localize "DHAM.Common.Thresholds"}}</span>
         <span class="stat-value">{{currentStats.thresholds}}</span>
     </div>
     <div class="stat-row">
-        <span class="stat-label">Attack Bonus</span>
+        <span class="stat-label">{{localize "DHAM.Common.AttackBonus"}}</span>
         <span class="stat-value">
             {{#if currentStats.hitChance}}
                 <span class="lm-hit-chance-hint" title="{{currentStats.hitChance.tooltip}}">{{currentStats.hitChance.text}}</span>
@@ -44,7 +44,7 @@
         </span>
     </div>
     <div class="stat-row">
-        <span class="stat-label">Critical Threshold</span>
+        <span class="stat-label">{{localize "DAGGERHEART.ACTIONS.Settings.criticalThreshold"}}</span>
         <span class="stat-value">
             <span class="lm-crit-chance-hint">{{currentStats.critChance}}</span>
             {{currentStats.critical}}
@@ -54,7 +54,7 @@
     <div class="stat-group">
         <div class="lm-stat-group-header">
             <span class="stat-label">
-                Attack Damage
+                {{localize "DHAM.Common.AttackDamage"}}
                 {{#if currentStats.damageTypesLabel}}
                     <span class="current-hint-text">{{currentStats.damageTypesLabel}}</span>
                 {{/if}}
@@ -69,7 +69,7 @@
     {{#if isHorde}}
         {{#if currentStats.halvedDamage}}
         <div class="stat-group">
-            <span class="stat-label">Halved Damage (Horde)</span>
+            <span class="stat-label">{{localize "DHAM.Common.HalvedDamageHorde"}}</span>
             <div class="stat-block">{{currentStats.halvedDamage}} <span class="current-hint-text">{{currentStats.halvedDamageStats}}</span></div>
         </div>
         {{/if}}
@@ -77,7 +77,7 @@
 
     {{#if currentStats.experiences.length}}
         <div class="stat-group">
-            <span class="stat-label">Experiences</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.Experience.plural"}}</span>
             <div class="stat-block stat-block-auto">
                 {{#each currentStats.experiences}}
                     {{this.name}} {{this.value}}{{#unless @last}}, {{/unless}}
@@ -97,7 +97,7 @@
         </div>
     </div>
     <div class="preview-note lm-portrait-note">
-        <i class="fas fa-external-link-alt"></i> Click image to open sheet
+        <i class="fas fa-external-link-alt"></i> {{localize "DHAM.LiveManager.ClickImageOpenSheet"}}
     </div>
     {{/if}}
 

--- a/templates/partials/lm-feature-changes.hbs
+++ b/templates/partials/lm-feature-changes.hbs
@@ -1,13 +1,13 @@
 <!-- FEATURES SECTION -->
 <div class="features-preview-section">
-    <h4 class="features-header">Feature Changes</h4>
+    <h4 class="features-header">{{localize "DHAM.LiveManager.FeatureChanges"}}</h4>
     {{#if featurePreviewData.length}}
         <div class="feature-changes-list">
             {{#each featurePreviewData}}
                 <div class="feature-change-row feature-change-row-layout">
                     <div class="feature-label feature-label-layout">
                         {{#if this.img}}
-                            <a class="feature-icon-link" data-action="openFeature" data-uuid="{{this.uuid}}" title="Open Item">
+                            <a class="feature-icon-link" data-action="openFeature" data-uuid="{{this.uuid}}" title="{{localize "DHAM.LiveManager.OpenItem"}}">
                                 <img src="{{this.img}}" class="feature-icon-img">
                             </a>
                         {{/if}}
@@ -37,7 +37,7 @@
                             </div>
                         {{else if this.isMinionFeature}}
                             <div class="minion-group">
-                                Minion ( <input type="number" class="minion-val-input" data-itemid="{{this.itemId}}" value="{{this.minionValue}}"> )
+                                {{localize "DAGGERHEART.CONFIG.AdversaryType.minion.label"}} ( <input type="number" class="minion-val-input" data-itemid="{{this.itemId}}" value="{{this.minionValue}}"> )
                             </div>
                         {{else if this.isDamageReadonly}}
                             <div class="feature-input-group">
@@ -45,7 +45,7 @@
                             </div>
                         {{else}}
                             {{#if this.isRenamed}}
-                                <input type="text" class="feature-override-input" data-itemid="{{this.itemId}}" value="{{this.newName}}" title="Rename Feature">
+                                <input type="text" class="feature-override-input" data-itemid="{{this.itemId}}" value="{{this.newName}}" title="{{localize "DHAM.Common.RenameFeature"}}">
                             {{else}}
                                 <div class="feature-new-static">{{this.newName}}</div>
                             {{/if}}
@@ -55,6 +55,6 @@
             {{/each}}
         </div>
     {{else}}
-        <div class="no-changes">No modified features.</div>
+        <div class="no-changes">{{localize "DHAM.LiveManager.NoModifiedFeatures"}}</div>
     {{/if}}
 </div>

--- a/templates/partials/lm-new-features.hbs
+++ b/templates/partials/lm-new-features.hbs
@@ -2,7 +2,7 @@
 {{#if allSuggestedFeatures.length}}
 <div class="features-preview-section">
     <div class="lm-new-features-header">
-        <h4 class="features-header lm-new-features-title">New Features</h4>
+        <h4 class="features-header lm-new-features-title">{{localize "DHAM.LiveManager.NewFeatures"}}</h4>
         <div class="feature-header-controls">
             <select class="suggestion-tier-select">
                 {{#each suggestedFeaturesTierOptions}}
@@ -42,7 +42,7 @@
                         {{/if}}
 
                         {{#if this.isRuleSuggestion}}
-                            <i class="fas fa-star new-feature-star" title="Recommended"></i>
+                            <i class="fas fa-star new-feature-star" title="{{localize "DHAM.Common.Recommended"}}"></i>
                         {{/if}}
                     </a>
                 </label>

--- a/templates/partials/lm-preview-stats.hbs
+++ b/templates/partials/lm-preview-stats.hbs
@@ -1,8 +1,8 @@
 <!-- Right Column: Preview State -->
 <div class="preview-column future-column">
     <h3 class="col-header future-header lm-preview-header">
-        <span>Preview (T{{previewStats.tier}})</span>
-        <input type="text" class="preview-actor-name-input" value="{{previewActorName}}" placeholder="New Actor Name" title="Name for new actor">
+        <span>{{localize "DAGGERHEART.GENERAL.preview"}} (T{{previewStats.tier}})</span>
+        <input type="text" class="preview-actor-name-input" value="{{previewActorName}}" placeholder="{{localize "DHAM.LiveManager.NewActorName"}}" title="{{localize "DHAM.LiveManager.NameForNewActor"}}">
     </h3>
 
     {{#if previewStats.error}}
@@ -10,7 +10,7 @@
     {{else}}
 
         <div class="stat-row">
-            <span class="stat-label">Difficulty</span>
+            <span class="stat-label">{{localize "DAGGERHEART.GENERAL.difficulty"}}</span>
             <div class="stat-input-group">
                 <span class="stat-value-hint">
                     {{#if previewStats.hitChanceAgainst}}
@@ -18,44 +18,44 @@
                     {{/if}}
                     {{{previewStats.difficultyDisplay}}}
                 </span>
-                <input type="number" class="override-input" data-field="difficulty" value="{{previewStats.difficulty}}" title="Manual Override">
+                <input type="number" class="override-input" data-field="difficulty" value="{{previewStats.difficulty}}" title="{{localize "DHAM.Common.ManualOverride"}}">
             </div>
         </div>
 
         <!-- HP & STRESS ROW (PREVIEW) -->
         <div class="stat-row-dual">
             <div class="stat-col-half">
-                <span class="stat-label">HP</span>
+                <span class="stat-label">{{localize "DAGGERHEART.GENERAL.HitPoints.short"}}</span>
                 <div class="stat-input-group dual-compact">
                     <span class="stat-value-hint">{{{previewStats.hpDisplay}}}</span>
-                    <input type="number" class="override-input" data-field="hp" value="{{previewStats.hp}}" title="Manual Override" {{#if previewStats.isMinion}}disabled{{/if}}>
+                    <input type="number" class="override-input" data-field="hp" value="{{previewStats.hp}}" title="{{localize "DHAM.Common.ManualOverride"}}" {{#if previewStats.isMinion}}disabled{{/if}}>
                 </div>
             </div>
             <div class="stat-separator"></div>
             <div class="stat-col-half">
-                <span class="stat-label">Stress</span>
+                <span class="stat-label">{{localize "DAGGERHEART.GENERAL.stress"}}</span>
                 <div class="stat-input-group dual-compact">
                     <span class="stat-value-hint">{{{previewStats.stressDisplay}}}</span>
-                    <input type="number" class="override-input" data-field="stress" value="{{previewStats.stress}}" title="Manual Override">
+                    <input type="number" class="override-input" data-field="stress" value="{{previewStats.stress}}" title="{{localize "DHAM.Common.ManualOverride"}}">
                 </div>
             </div>
         </div>
 
         <div class="stat-row">
-            <span class="stat-label">Thresholds</span>
+            <span class="stat-label">{{localize "DHAM.Common.Thresholds"}}</span>
             <div class="stat-input-group dual-input">
                 <span class="stat-value-hint">{{{previewStats.thresholdsDisplay}}}</span>
                 {{#if previewStats.isMinion}}
                 {{else}}
-                    <input type="number" class="override-input small" data-field="major" value="{{previewStats.major}}" placeholder="Maj" title="Major">
+                    <input type="number" class="override-input small" data-field="major" value="{{previewStats.major}}" placeholder="{{localize "DHAM.LiveManager.MajorShort"}}" title="{{localize "DHAM.CompendiumStats.ThresholdMin"}}">
                     /
-                    <input type="number" class="override-input small" data-field="severe" value="{{previewStats.severe}}" placeholder="Sev" title="Severe">
+                    <input type="number" class="override-input small" data-field="severe" value="{{previewStats.severe}}" placeholder="{{localize "DHAM.LiveManager.SevereShort"}}" title="{{localize "DHAM.CompendiumStats.ThresholdMax"}}">
                 {{/if}}
             </div>
         </div>
 
         <div class="stat-row">
-            <span class="stat-label">Attack Bonus</span>
+            <span class="stat-label">{{localize "DHAM.Common.AttackBonus"}}</span>
             <div class="stat-input-group">
                 <span class="stat-value-hint">
                     {{#if previewStats.hitChance}}
@@ -63,11 +63,11 @@
                     {{/if}}
                     {{{previewStats.attackModDisplay}}}
                 </span>
-                <input type="number" class="override-input" data-field="attackMod" value="{{previewStats.attackMod}}" title="Manual Override">
+                <input type="number" class="override-input" data-field="attackMod" value="{{previewStats.attackMod}}" title="{{localize "DHAM.Common.ManualOverride"}}">
             </div>
         </div>
         <div class="stat-row">
-            <span class="stat-label">Critical Threshold</span>
+            <span class="stat-label">{{localize "DAGGERHEART.ACTIONS.Settings.criticalThreshold"}}</span>
             <div class="stat-input-group">
                  <span class="stat-value-hint lm-crit-chance-hint-accent">{{previewStats.critChance}}</span>
                 <select class="override-input critical-select lm-critical-select">
@@ -82,10 +82,10 @@
         <div class="stat-row-dual lm-damage-config-row">
             <!-- Left: Damage Types -->
             <div class="stat-col-half lm-damage-type-col">
-                <span class="stat-label lm-type-label">Damage Type:</span>
+                <span class="stat-label lm-type-label">{{localize "DHAM.Common.DamageType"}}</span>
                 <div class="damage-type-controls">
-                    <label class="lm-damage-type-label" title="Physical Damage"><input type="checkbox" class="damage-type-checkbox" value="physical" {{#if isPhysical}}checked{{/if}}> Phys</label>
-                    <label class="lm-damage-type-label" title="Magical Damage"><input type="checkbox" class="damage-type-checkbox" value="magical" {{#if isMagical}}checked{{/if}}> Mag</label>
+                    <label class="lm-damage-type-label" title="{{localize "DAGGERHEART.GENERAL.Damage.physicalDamage"}}"><input type="checkbox" class="damage-type-checkbox" value="physical" {{#if isPhysical}}checked{{/if}}> {{localize "DHAM.LiveManager.PhysShort"}}</label>
+                    <label class="lm-damage-type-label" title="{{localize "DAGGERHEART.GENERAL.Damage.magicalDamage"}}"><input type="checkbox" class="damage-type-checkbox" value="magical" {{#if isMagical}}checked{{/if}}> {{localize "DAGGERHEART.CONFIG.DamageType.magical.abbreviation"}}</label>
                 </div>
             </div>
 
@@ -94,7 +94,7 @@
 
             <!-- Right: Direct Damage -->
             <div class="stat-col-half lm-direct-col">
-                <span class="stat-label lm-type-label">Direct:</span>
+                <span class="stat-label lm-type-label">{{localize "DHAM.Common.Direct"}}</span>
                 <select class="override-input direct-select lm-direct-select">
                     {{#each directOptions}}
                     <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
@@ -107,7 +107,7 @@
         <div class="stat-group">
             <div class="lm-damage-header">
                 <span class="stat-label lm-damage-label">
-                    Attack Damage
+                    {{localize "DHAM.Common.AttackDamage"}}
                 </span>
 
                 <div class="feature-input-group lm-damage-input-group">
@@ -122,7 +122,7 @@
         <!-- Halved Damage Layout -->
         <div class="stat-group">
             <div class="lm-damage-header">
-                <span class="stat-label">Halved Damage (Horde)</span>
+                <span class="stat-label">{{localize "DHAM.Common.HalvedDamageHorde"}}</span>
 
                 <div class="feature-input-group lm-damage-input-group">
                     <span class="preview-hint-text lm-hint-nowrap">{{previewStats.halvedDamageStats}}</span>
@@ -134,24 +134,24 @@
         {{/if}}
 
         <div class="preview-note lm-info-note">
-            <i class="fas fa-info-circle"></i> Edit values to override random rolls.
+            <i class="fas fa-info-circle"></i> {{localize "DHAM.LiveManager.EditValues"}}
         </div>
 
         <!-- PREVIEW EXPERIENCES -->
         <div class="stat-group">
             <div class="lm-exp-header">
                 <span class="stat-label">
-                    Experiences
+                    {{localize "DAGGERHEART.GENERAL.Experience.plural"}}
                     <i class="fas fa-question-circle suggestion-icon" data-tooltip="{{{previewStats.expTooltip}}}"></i>
                 </span>
-                <button type="button" data-action="addExperience" class="add-btn-small" title="Add Experience"><i class="fas fa-plus"></i></button>
+                <button type="button" data-action="addExperience" class="add-btn-small" title="{{localize "DHAM.LiveManager.AddExperience"}}"><i class="fas fa-plus"></i></button>
             </div>
             <div class="stat-block-list experiences-list">
                 {{#each previewStats.experiences}}
                     <div class="exp-item-preview {{#if this.isNew}}exp-new{{/if}}">
-                        <input type="text" class="exp-name-input" data-id="{{this.id}}" value="{{this.name}}" placeholder="Exp Name">
+                        <input type="text" class="exp-name-input" data-id="{{this.id}}" value="{{this.name}}" placeholder="{{localize "DHAM.LiveManager.ExpName"}}">
 
-                        <button type="button" data-action="rollExperienceName" data-id="{{this.id}}" class="roll-btn-small" title="Roll Random Name">
+                        <button type="button" data-action="rollExperienceName" data-id="{{this.id}}" class="roll-btn-small" title="{{localize "DHAM.LiveManager.RollRandomName"}}">
                             <i class="fas fa-dice"></i>
                         </button>
 
@@ -160,7 +160,7 @@
                                 <option value="{{this.value}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
                             {{/each}}
                         </select>
-                        <button type="button" data-action="deleteExperience" data-id="{{this.id}}" class="delete-btn-small" title="Remove"><i class="fas fa-trash"></i></button>
+                        <button type="button" data-action="deleteExperience" data-id="{{this.id}}" class="delete-btn-small" title="{{localize "DHAM.Common.Remove"}}"><i class="fas fa-trash"></i></button>
                     </div>
                 {{/each}}
             </div>


### PR DESCRIPTION
## Summary

This updates the module for Foundry VTT v14 and Daggerheart 2.x compatibility.

## Changes

- Update the module manifest to version 0.2.8 with v14 compatibility metadata.
- Add compatibility helpers for AppV2 instance lookup and safe compendium document creation.
- Handle Daggerheart v14 keyed `system.attack.damage.parts` data in Live Manager, damage updates, and compendium stats.
- Avoid stale `ui.windows` assumptions for AppV2 windows.
- Use safer compendium document cloning when creating encounter actors and embedded feature items.

## Root Cause

Foundry/Daggerheart v14 can expose damage parts as keyed objects rather than arrays, and AppV2 windows are not reliably discoverable through the legacy `ui.windows` path. Creating world documents directly from compendium `toObject()` data can also carry identity or stats fields that are fragile under stricter v14 validation.